### PR TITLE
Move Crowdin config to website directory

### DIFF
--- a/website/crowdin.yaml
+++ b/website/crowdin.yaml
@@ -1,6 +1,6 @@
 project_identifier_env: CROWDIN_WARRIORJS_PROJECT_ID
 api_key_env: CROWDIN_WARRIORJS_API_KEY
-base_path: "./"
+base_path: "../"
 preserve_hierarchy: true
 
 files:

--- a/website/package.json
+++ b/website/package.json
@@ -9,9 +9,8 @@
     "write-translations": "docusaurus-write-translations",
     "version": "docusaurus-version",
     "rename-version": "docusaurus-rename-version",
-    "crowdin-upload":
-      "crowdin --config ../crowdin.yaml upload sources --auto-update -b master",
-    "crowdin-download": "crowdin --config ../crowdin.yaml download -b master"
+    "crowdin-upload": "crowdin upload sources --auto-update -b master",
+    "crowdin-download": "crowdin download -b master"
   },
   "devDependencies": {
     "docusaurus": "^1.0.14"


### PR DESCRIPTION
This helps simplifying the Crowdin commands in the website's `package.json` while keeping the project's root cleaner.