### PR TITLE
Add warrior score next to health in play log (#48)

### DIFF
--- a/packages/warriorjs-cli/src/ui/printBoard.js
+++ b/packages/warriorjs-cli/src/ui/printBoard.js
@@ -4,7 +4,7 @@ import print from './print';
 import printFloorMap from './printFloorMap';
 import printWarriorStatus from './printWarriorStatus';
 
-const warriorStatusRows = 1;
+const warriorStatusRows = 2;
 
 /**
  * Prints the game board after moving the cursor up a given number of rows.

--- a/packages/warriorjs-cli/src/ui/printBoard.test.js
+++ b/packages/warriorjs-cli/src/ui/printBoard.test.js
@@ -26,7 +26,7 @@ test('moves cursor up and down with offset', () => {
     warrior: {},
   };
   printBoard(floor, 1);
-  expect(print).toHaveBeenCalledWith(ansiEscapes.cursorUp(3));
+  expect(print).toHaveBeenCalledWith(ansiEscapes.cursorUp(4));
   expect(printWarriorStatus).toHaveBeenCalledWith(floor.warrior);
   expect(printFloorMap).toHaveBeenCalledWith(floor.map);
   expect(print).toHaveBeenCalledWith(ansiEscapes.cursorDown(1));

--- a/packages/warriorjs-cli/src/ui/printWarriorStatus.js
+++ b/packages/warriorjs-cli/src/ui/printWarriorStatus.js
@@ -10,10 +10,15 @@ import printLine from './printLine';
  */
 function printWarriorStatus(warrior) {
   const [screenWidth] = getScreenSize();
-  const warriorStatus = chalk.red(
+  const warriorHealth = chalk.redBright(
     `♥ ${warrior.health}`.padEnd(screenWidth, ' '),
   );
-  printLine(warriorStatus);
+  printLine(warriorHealth);
+
+  const warriorScore = chalk.yellowBright(
+    `⬥ ${warrior.score}`.padEnd(screenWidth, ' '),
+  );
+  printLine(warriorScore);
 }
 
 export default printWarriorStatus;

--- a/packages/warriorjs-cli/src/ui/printWarriorStatus.test.js
+++ b/packages/warriorjs-cli/src/ui/printWarriorStatus.test.js
@@ -7,13 +7,24 @@ import printWarriorStatus from './printWarriorStatus';
 jest.mock('./getScreenSize');
 jest.mock('./printLine');
 
-test('prints warrior health in red', () => {
+test('prints warrior health in bright red', () => {
   getScreenSize.mockReturnValue([5, 0]);
   const warrior = {
     health: 20,
   };
   printWarriorStatus(warrior);
   expect(printLine).toHaveBeenCalledWith(
-    `${style.red.open}♥ 20 ${style.red.close}`,
+    `${style.redBright.open}♥ 20 ${style.redBright.close}`,
+  );
+});
+
+test('prints warrior score in bright yellow', () => {
+  getScreenSize.mockReturnValue([5, 0]);
+  const warrior = {
+    score: 10,
+  };
+  printWarriorStatus(warrior);
+  expect(printLine).toHaveBeenCalledWith(
+    `${style.yellowBright.open}⬥ 10 ${style.yellowBright.close}`,
   );
 });

--- a/packages/warriorjs-core/src/Warrior.js
+++ b/packages/warriorjs-core/src/Warrior.js
@@ -43,6 +43,7 @@ class Warrior extends Unit {
     return {
       ...super.toJSON(),
       warrior: true,
+      score: this.score,
     };
   }
 }


### PR DESCRIPTION
Allows users to see how their score changes turn by turn.

Change health color from red to bright red.