### PR TITLE
Fix path normalization in tests

### DIFF
--- a/packages/warriorjs-cli/src/Game.test.js
+++ b/packages/warriorjs-cli/src/Game.test.js
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import path from 'path';
 
 import mock from 'mock-fs';
 import { getLevel } from '@warriorjs/core';
@@ -31,7 +32,9 @@ describe('Game', () => {
   });
 
   test('has a game directory path', () => {
-    expect(game.gameDirectoryPath).toBe('/path/to/game/warriorjs');
+    expect(game.gameDirectoryPath).toBe(
+      path.normalize('/path/to/game/warriorjs'),
+    );
   });
 
   describe('when loading profile', () => {

--- a/packages/warriorjs-cli/src/Profile.test.js
+++ b/packages/warriorjs-cli/src/Profile.test.js
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import path from 'path';
 
 import mock from 'mock-fs';
 
@@ -19,7 +20,9 @@ describe('Profile.load', () => {
     expect(profile).toBeInstanceOf(Profile);
     expect(profile.warriorName).toBe('Joe');
     expect(profile.towerName).toBe('beginner');
-    expect(profile.directoryPath).toBe('/path/to/profile');
+    expect(path.normalize(profile.directoryPath)).toBe(
+      path.normalize('/path/to/profile'),
+    );
     expect(profile.foo).toBe(42);
   });
 
@@ -131,11 +134,15 @@ describe('Profile', () => {
   });
 
   test('knows the path to the player code file', () => {
-    expect(profile.getPlayerCodeFilePath()).toBe('/path/to/profile/Player.js');
+    expect(profile.getPlayerCodeFilePath()).toBe(
+      path.normalize('/path/to/profile/Player.js'),
+    );
   });
 
   test('knows the path to the README file', () => {
-    expect(profile.getReadmeFilePath()).toBe('/path/to/profile/README.md');
+    expect(profile.getReadmeFilePath()).toBe(
+      path.normalize('/path/to/profile/README.md'),
+    );
   });
 
   describe('when going to the next level', () => {
@@ -223,7 +230,9 @@ describe('Profile', () => {
   });
 
   test('knows the path to the profile file', () => {
-    expect(profile.getProfileFilePath()).toBe('/path/to/profile/.profile');
+    expect(profile.getProfileFilePath()).toBe(
+      path.normalize('/path/to/profile/.profile'),
+    );
   });
 
   test('encodes with JSON + base64', () => {


### PR DESCRIPTION
Previously, running tests on a non-posix machine (eg. Windows) would
cause several to fail. The cause of the failure was file path comparison.
The expected values were written as posix style file paths (eg. a/b/c.txt)
while the actual values were returning windows style file paths (eg. a\\b\\c.txt).

The solution to this was to use node's built in path module to normalize
the paths for each system (https://nodejs.org/api/path.html#path_path_normalize_path).

closes #76 