### PR TITLE
Subtract reward points when killing a friendly unit

### DIFF
--- a/packages/warriorjs-core/src/Unit.js
+++ b/packages/warriorjs-core/src/Unit.js
@@ -159,7 +159,11 @@ class Unit {
   damage(receiver, amount) {
     receiver.takeDamage(amount);
     if (!receiver.isAlive()) {
-      this.earnPoints(receiver.reward);
+      if (receiver.isCaptive()) {
+        this.losePoints(receiver.reward);
+      } else {
+        this.earnPoints(receiver.reward);
+      }
     }
   }
 
@@ -205,6 +209,18 @@ class Unit {
    */
   earnPoints(points) {
     this.score += points;
+  }
+
+  /**
+   * Substract the given points from the score.
+   *
+   * @param {number} points The points to lose.
+   */
+  losePoints(points) {
+    this.score -= points;
+    if (this.score < 0) {
+      this.score = 0;
+    }
   }
 
   /**

--- a/packages/warriorjs-core/src/Unit.js
+++ b/packages/warriorjs-core/src/Unit.js
@@ -212,15 +212,12 @@ class Unit {
   }
 
   /**
-   * Substract the given points from the score.
+   * Subtract the given points from the score.
    *
    * @param {number} points The points to lose.
    */
   losePoints(points) {
     this.score -= points;
-    if (this.score < 0) {
-      this.score = 0;
-    }
   }
 
   /**

--- a/packages/warriorjs-core/src/Unit.test.js
+++ b/packages/warriorjs-core/src/Unit.test.js
@@ -228,6 +228,13 @@ describe('Unit', () => {
       unit.damage(receiver, 3);
       expect(unit.earnPoints).not.toHaveBeenCalled();
     });
+
+    test('lose points equal to reward when killing a friendly unit', () => {
+      receiver.captive = true;
+      unit.losePoints = jest.fn();
+      unit.damage(receiver, 5);
+      expect(unit.losePoints).toHaveBeenCalledWith(10);
+    });
   });
 
   test('considers itself alive with position', () => {
@@ -271,6 +278,18 @@ describe('Unit', () => {
   test('can earn points', () => {
     unit.earnPoints(5);
     expect(unit.score).toBe(5);
+  });
+
+  test('can lose points', () => {
+    unit.score = 10;
+    unit.losePoints(5);
+    expect(unit.score).toBe(5);
+  });
+
+  test("can't lose points under zero", () => {
+    unit.score = 3;
+    unit.losePoints(5);
+    expect(unit.score).toBe(0);
   });
 
   test("doesn't fetch itself when fetching other units", () => {

--- a/packages/warriorjs-core/src/Unit.test.js
+++ b/packages/warriorjs-core/src/Unit.test.js
@@ -286,10 +286,10 @@ describe('Unit', () => {
     expect(unit.score).toBe(5);
   });
 
-  test("can't lose points under zero", () => {
+  test('can lose points under zero', () => {
     unit.score = 3;
     unit.losePoints(5);
-    expect(unit.score).toBe(0);
+    expect(unit.score).toBe(-2);
   });
 
   test("doesn't fetch itself when fetching other units", () => {


### PR DESCRIPTION
When killing a friendly unit, subtracts its reward points.

To implement this, the new method `losePoints` has been added to the `Unit` class, which will substract the given points from the unit ~(but doesn't decrement its score under zero)~.

Closes #62