### PR TITLE
Add think ability

### DIFF
--- a/packages/warriorjs-abilities/README.md
+++ b/packages/warriorjs-abilities/README.md
@@ -77,3 +77,11 @@ Returns an array of up to `[range]` [spaces][spaces] in the given direction
 [actions]: https://warrior.js.org/docs/abilities#actions
 [senses]: https://warrior.js.org/docs/abilities#senses
 [spaces]: https://warrior.js.org/docs/spaces
+
+### `unit.think(thought)`:
+
+Think about your options before choosing an action.
+
+[actions]: https://warrior.js.org/docs/abilities#actions
+[senses]: https://warrior.js.org/docs/abilities#senses
+[spaces]: https://warrior.js.org/docs/spaces

--- a/packages/warriorjs-abilities/src/index.js
+++ b/packages/warriorjs-abilities/src/index.js
@@ -12,4 +12,5 @@ export { default as pivot } from './pivot';
 export { default as rescue } from './rescue';
 export { default as rest } from './rest';
 export { default as shoot } from './shoot';
+export { default as think } from './think';
 export { default as walk } from './walk';

--- a/packages/warriorjs-abilities/src/think.js
+++ b/packages/warriorjs-abilities/src/think.js
@@ -1,0 +1,10 @@
+function think() {
+  return unit => ({
+    description: 'Think about your options before choosing an action.',
+    perform(thought) {
+      unit.say(`thinks ${thought || 'nothing'}`);
+    },
+  });
+}
+
+export default think;

--- a/packages/warriorjs-abilities/src/think.test.js
+++ b/packages/warriorjs-abilities/src/think.test.js
@@ -1,0 +1,33 @@
+import thinkCreator from './think';
+
+describe('think', () => {
+  let think;
+  let unit;
+
+  beforeEach(() => {
+    unit = { say: jest.fn() };
+    think = thinkCreator()(unit);
+  });
+
+  test('is not an action', () => {
+    expect(think.action).toBeUndefined();
+  });
+
+  test('has a description', () => {
+    expect(think.description).toBe(
+      `Think about your options before choosing an action.`,
+    );
+  });
+
+  describe('performing', () => {
+    test('thinks nothing by default', () => {
+      think.perform();
+      expect(unit.say).toHaveBeenCalledWith('thinks nothing');
+    });
+
+    test('allows to specify thought', () => {
+      think.perform('he should be brave');
+      expect(unit.say).toHaveBeenCalledWith('thinks he should be brave');
+    });
+  });
+});

--- a/packages/warriorjs-tower-beginner/src/index.js
+++ b/packages/warriorjs-tower-beginner/src/index.js
@@ -15,6 +15,7 @@ import {
   pivot,
   rescue,
   rest,
+  think,
   shoot,
   walk,
 } from '@warriorjs/abilities';
@@ -40,13 +41,14 @@ export default {
         },
         warrior: {
           ...Warrior,
+          abilities: {
+            think: think(),
+            walk: walk(),
+          },
           position: {
             x: 0,
             y: 0,
             facing: EAST,
-          },
-          abilities: {
-            walk: walk(),
           },
         },
         units: [],

--- a/packages/warriorjs-tower-intermediate/src/index.js
+++ b/packages/warriorjs-tower-intermediate/src/index.js
@@ -13,6 +13,7 @@ import {
   look,
   rescue,
   rest,
+  think,
   walk,
 } from '@warriorjs/abilities';
 import { ticking } from '@warriorjs/effects';
@@ -40,6 +41,7 @@ export default {
           ...Warrior,
           abilities: {
             directionOfStairs: directionOfStairs(),
+            think: think(),
             walk: walk(),
           },
           position: {


### PR DESCRIPTION
Think is a sense that allows the player to log arbitrary strings to the play log **before performing the action of the turn**.