### PR TITLE
Fixed diamond symbol on windows CMD

### DIFF
--- a/packages/warriorjs-cli/src/ui/printWarriorStatus.js
+++ b/packages/warriorjs-cli/src/ui/printWarriorStatus.js
@@ -2,7 +2,6 @@ import chalk from 'chalk';
 
 import getScreenSize from './getScreenSize';
 import printLine from './printLine';
-import isWindows from 'is-windows';
 
 /**
  * Prints the warrior status line.
@@ -17,7 +16,7 @@ function printWarriorStatus(warrior) {
   printLine(warriorHealth);
 
   const warriorScore = chalk.yellowBright(
-    `${isWindows ? `♦` : `⬥`} ${warrior.score}`.padEnd(screenWidth, ' '),
+    `♦ ${warrior.score}`.padEnd(screenWidth, ' '),
   );
   printLine(warriorScore);
 }

--- a/packages/warriorjs-cli/src/ui/printWarriorStatus.js
+++ b/packages/warriorjs-cli/src/ui/printWarriorStatus.js
@@ -2,6 +2,7 @@ import chalk from 'chalk';
 
 import getScreenSize from './getScreenSize';
 import printLine from './printLine';
+import isWindows from 'is-windows';
 
 /**
  * Prints the warrior status line.
@@ -16,7 +17,7 @@ function printWarriorStatus(warrior) {
   printLine(warriorHealth);
 
   const warriorScore = chalk.yellowBright(
-    `⬥ ${warrior.score}`.padEnd(screenWidth, ' '),
+    `${isWindows ? `♦` : `⬥`} ${warrior.score}`.padEnd(screenWidth, ' '),
   );
   printLine(warriorScore);
 }

--- a/packages/warriorjs-cli/src/ui/printWarriorStatus.test.js
+++ b/packages/warriorjs-cli/src/ui/printWarriorStatus.test.js
@@ -3,7 +3,6 @@ import style from 'ansi-styles';
 import getScreenSize from './getScreenSize';
 import printLine from './printLine';
 import printWarriorStatus from './printWarriorStatus';
-import isWindows from 'is-windows';
 
 jest.mock('./getScreenSize');
 jest.mock('./printLine');
@@ -26,8 +25,6 @@ test('prints warrior score in bright yellow', () => {
   };
   printWarriorStatus(warrior);
   expect(printLine).toHaveBeenCalledWith(
-    `${style.yellowBright.open}${isWindows ? `♦` : `⬥`} 10 ${
-      style.yellowBright.close
-    }`,
+    `${style.yellowBright.open}♦ 10 ${style.yellowBright.close}`,
   );
 });

--- a/packages/warriorjs-cli/src/ui/printWarriorStatus.test.js
+++ b/packages/warriorjs-cli/src/ui/printWarriorStatus.test.js
@@ -3,6 +3,7 @@ import style from 'ansi-styles';
 import getScreenSize from './getScreenSize';
 import printLine from './printLine';
 import printWarriorStatus from './printWarriorStatus';
+import isWindows from 'is-windows';
 
 jest.mock('./getScreenSize');
 jest.mock('./printLine');
@@ -25,6 +26,8 @@ test('prints warrior score in bright yellow', () => {
   };
   printWarriorStatus(warrior);
   expect(printLine).toHaveBeenCalledWith(
-    `${style.yellowBright.open}⬥ 10 ${style.yellowBright.close}`,
+    `${style.yellowBright.open}${isWindows ? `♦` : `⬥`} 10 ${
+      style.yellowBright.close
+    }`,
   );
 });


### PR DESCRIPTION
Hello!

This change should fix the diamond symbol on Windows' CMD.
I used the is-windows util to check the user env and in case that returns true, I use the Black Diamond Suit (as suggested on the issue), otherwise I keep the black medium diamond symbol.

I hope that helps.

Fixes #112 