### PR TITLE
Sensed space and sensed unit entities

### DIFF
--- a/docs/js-tips.md
+++ b/docs/js-tips.md
@@ -59,7 +59,7 @@ class Player {
 
   isEnemyInSight(warrior) {
     const spaceWithUnit = warrior.look().find(space => space.isUnit());
-    return spaceWithUnit && spaceWithUnit.getUnit().isHostile();
+    return spaceWithUnit && spaceWithUnit.getUnit().isEnemy();
   }
 }
 ```

--- a/docs/space-api.md
+++ b/docs/space-api.md
@@ -14,6 +14,16 @@ You can call methods on a space to gather information about what's there.
 
 Here are the various methods that are available to you:
 
+## `space.getLocation()`:
+
+Returns the location of this space as the number of spaces forward and to the
+right of your position.
+
+**Returns**
+
+_(number[])_: The relative location of this space as the offset
+`[forward, right]`.
+
 ## `space.isEmpty()`:
 
 Determines if nothing (except maybe stairs) is at this space.

--- a/docs/unit-api.md
+++ b/docs/unit-api.md
@@ -24,28 +24,8 @@ _(boolean)_: Whether this unit is bound or not.
 
 ## `unit.isHostile()`:
 
-Determines if the unit is hostile. A bound unit is not considered hostile.
+Determines if the unit is hostile.
 
 **Returns**
 
 _(boolean)_: Whether this is a hostile unit or not.
-
-## `unit.isFriendly()`:
-
-Determines if the unit is friendly.
-
-**Returns**
-
-_(boolean)_: Whether this is a friendly unit or not.
-
-## `unit.isWarrior()`:
-
-Determines if the unit is the warrior.
-
-**Aliases**
-
-_`unit.isPlayer()`_
-
-**Returns**
-
-_(boolean)_: Whether this unit is the warrior or not.

--- a/docs/unit-api.md
+++ b/docs/unit-api.md
@@ -22,10 +22,10 @@ Determines if the unit is bound.
 
 _(boolean)_: Whether this unit is bound or not.
 
-## `unit.isHostile()`:
+## `unit.isEnemy()`:
 
-Determines if the unit is hostile.
+Determines if the unit is an enemy.
 
 **Returns**
 
-_(boolean)_: Whether this is a hostile unit or not.
+_(boolean)_: Whether this is an enemy unit or not.

--- a/packages/warriorjs-abilities/src/feel.js
+++ b/packages/warriorjs-abilities/src/feel.js
@@ -6,7 +6,7 @@ function feel() {
   return unit => ({
     description: `Return the adjacent space in the given direction (${defaultDirection} by default).`,
     perform(direction = defaultDirection) {
-      return unit.getSpaceAt(direction).toPlayerObject();
+      return unit.getSensedSpaceAt(direction);
     },
   });
 }

--- a/packages/warriorjs-abilities/src/feel.test.js
+++ b/packages/warriorjs-abilities/src/feel.test.js
@@ -7,7 +7,7 @@ describe('feel', () => {
   let unit;
 
   beforeEach(() => {
-    unit = { getSpaceAt: jest.fn() };
+    unit = { getSensedSpaceAt: jest.fn() };
     feel = feelCreator()(unit);
   });
 
@@ -22,21 +22,18 @@ describe('feel', () => {
   });
 
   describe('performing', () => {
-    beforeEach(() => {
-      unit.getSpaceAt.mockReturnValue({ toPlayerObject: () => 'space' });
-    });
-
     test('feels forward by default', () => {
       feel.perform();
-      expect(unit.getSpaceAt).toHaveBeenCalledWith(FORWARD);
+      expect(unit.getSensedSpaceAt).toHaveBeenCalledWith(FORWARD);
     });
 
     test('allows to specify direction', () => {
       feel.perform(LEFT);
-      expect(unit.getSpaceAt).toHaveBeenCalledWith(LEFT);
+      expect(unit.getSensedSpaceAt).toHaveBeenCalledWith(LEFT);
     });
 
     test('returns adjacent space in specified direction', () => {
+      unit.getSensedSpaceAt.mockReturnValue('space');
       expect(feel.perform()).toBe('space');
     });
   });

--- a/packages/warriorjs-abilities/src/listen.js
+++ b/packages/warriorjs-abilities/src/listen.js
@@ -1,3 +1,5 @@
+import { FORWARD, getRelativeOffset } from '@warriorjs/geography';
+
 function listen() {
   return unit => ({
     description:
@@ -5,7 +7,16 @@ function listen() {
     perform() {
       return unit
         .getOtherUnits()
-        .map(anotherUnit => anotherUnit.getSpace().toPlayerObject());
+        .map(anotherUnit =>
+          getRelativeOffset(
+            anotherUnit.getSpace().location,
+            unit.position.location,
+            unit.position.orientation,
+          ),
+        )
+        .map(([forward, right]) =>
+          unit.getSensedSpaceAt(FORWARD, forward, right),
+        );
     },
   });
 }

--- a/packages/warriorjs-abilities/src/listen.test.js
+++ b/packages/warriorjs-abilities/src/listen.test.js
@@ -1,3 +1,5 @@
+import { FORWARD, NORTH } from '@warriorjs/geography';
+
 import listenCreator from './listen';
 
 describe('listen', () => {
@@ -6,10 +8,15 @@ describe('listen', () => {
 
   beforeEach(() => {
     unit = {
+      position: {
+        location: [1, 1],
+        orientation: NORTH,
+      },
       getOtherUnits: () => [
-        { getSpace: () => ({ toPlayerObject: () => 'space1' }) },
-        { getSpace: () => ({ toPlayerObject: () => 'space2' }) },
+        { getSpace: () => ({ location: [0, 0] }) },
+        { getSpace: () => ({ location: [2, 3] }) },
       ],
+      getSensedSpaceAt: jest.fn(),
     };
     listen = listenCreator()(unit);
   });
@@ -26,7 +33,12 @@ describe('listen', () => {
 
   describe('performing', () => {
     test('returns all spaces which have units in them', () => {
+      unit.getSensedSpaceAt
+        .mockReturnValueOnce('space1')
+        .mockReturnValueOnce('space2');
       expect(listen.perform()).toEqual(['space1', 'space2']);
+      expect(unit.getSensedSpaceAt).toHaveBeenCalledWith(FORWARD, 1, -1);
+      expect(unit.getSensedSpaceAt).toHaveBeenCalledWith(FORWARD, -2, 1);
     });
   });
 });

--- a/packages/warriorjs-abilities/src/look.js
+++ b/packages/warriorjs-abilities/src/look.js
@@ -7,9 +7,7 @@ function look({ range }) {
     description: `Returns an array of up to ${range} spaces in the given direction (${defaultDirection} by default).`,
     perform(direction = defaultDirection) {
       const offsets = Array.from(new Array(range), (_, index) => index + 1);
-      return offsets.map(offset =>
-        unit.getSpaceAt(direction, offset).toPlayerObject(),
-      );
+      return offsets.map(offset => unit.getSensedSpaceAt(direction, offset));
     },
   });
 }

--- a/packages/warriorjs-abilities/src/look.test.js
+++ b/packages/warriorjs-abilities/src/look.test.js
@@ -7,7 +7,7 @@ describe('look', () => {
   let unit;
 
   beforeEach(() => {
-    unit = { getSpaceAt: jest.fn() };
+    unit = { getSensedSpaceAt: jest.fn() };
     look = lookCreator({ range: 3 })(unit);
   });
 
@@ -22,30 +22,22 @@ describe('look', () => {
   });
 
   describe('performing', () => {
-    beforeEach(() => {
-      unit.getSpaceAt
-        .mockReturnValueOnce({ toPlayerObject: () => 'space1' })
-        .mockReturnValueOnce({ toPlayerObject: () => 'space2' })
-        .mockReturnValueOnce({ toPlayerObject: () => 'space3' })
-        .mockReturnValueOnce({ toPlayerObject: () => 'space4' });
-    });
-
     test('looks forward by default', () => {
       look.perform();
-      expect(unit.getSpaceAt).toHaveBeenCalledWith(FORWARD, 1);
-      expect(unit.getSpaceAt).toHaveBeenCalledWith(FORWARD, 2);
-      expect(unit.getSpaceAt).toHaveBeenCalledWith(FORWARD, 3);
+      expect(unit.getSensedSpaceAt).toHaveBeenCalledWith(FORWARD, 1);
+      expect(unit.getSensedSpaceAt).toHaveBeenCalledWith(FORWARD, 2);
+      expect(unit.getSensedSpaceAt).toHaveBeenCalledWith(FORWARD, 3);
     });
 
     test('allows to specify direction', () => {
       look.perform(LEFT);
-      expect(unit.getSpaceAt).toHaveBeenCalledWith(LEFT, 1);
-      expect(unit.getSpaceAt).toHaveBeenCalledWith(LEFT, 2);
-      expect(unit.getSpaceAt).toHaveBeenCalledWith(LEFT, 3);
+      expect(unit.getSensedSpaceAt).toHaveBeenCalledWith(LEFT, 1);
+      expect(unit.getSensedSpaceAt).toHaveBeenCalledWith(LEFT, 2);
+      expect(unit.getSensedSpaceAt).toHaveBeenCalledWith(LEFT, 3);
     });
 
     test('returns adjacent space in specified direction', () => {
-      unit.getSpaceAt
+      unit.getSensedSpaceAt
         .mockReturnValueOnce('space1')
         .mockReturnValueOnce('space2')
         .mockReturnValueOnce('space3')

--- a/packages/warriorjs-core/src/Floor.test.js
+++ b/packages/warriorjs-core/src/Floor.test.js
@@ -42,13 +42,13 @@ describe('Floor', () => {
 
   test('returns the space at the stairs location', () => {
     const stairsSpace = floor.getStairsSpace();
-    expect(stairsSpace.getLocation()).toEqual(floor.stairsLocation);
+    expect(stairsSpace.location).toEqual(floor.stairsLocation);
   });
 
   test('returns the space at the specified location', () => {
     const space = floor.getSpaceAt([0, 0]);
     expect(space).toBeInstanceOf(Space);
-    expect(space.getLocation()).toEqual([0, 0]);
+    expect(space.location).toEqual([0, 0]);
   });
 
   test('adds a unit and fetches it at that position', () => {

--- a/packages/warriorjs-core/src/Level.js
+++ b/packages/warriorjs-core/src/Level.js
@@ -73,7 +73,7 @@ class Level {
    */
   wasPassed() {
     const stairsSpace = this.floor.getStairsSpace();
-    return stairsSpace.isUnit() && stairsSpace.getUnit().isWarrior();
+    return stairsSpace.getUnit() === this.floor.warrior;
   }
 
   /**

--- a/packages/warriorjs-core/src/LevelLoader.js
+++ b/packages/warriorjs-core/src/LevelLoader.js
@@ -25,21 +25,14 @@ class LevelLoader {
         character,
         maxHealth,
         reward,
-        hostile,
+        enemy,
         bound,
         position,
         abilities,
         effects,
         playTurn,
       }) => {
-        const unit = new Unit(
-          name,
-          character,
-          maxHealth,
-          reward,
-          hostile,
-          bound,
-        );
+        const unit = new Unit(name, character, maxHealth, reward, enemy, bound);
         this.setUpUnit(unit, position, abilities, effects);
         unit.playTurn = playTurn;
       },

--- a/packages/warriorjs-core/src/Position.js
+++ b/packages/warriorjs-core/src/Position.js
@@ -74,7 +74,7 @@ class Position {
    * @returns {number} The distance of the space.
    */
   getDistanceOf(space) {
-    return getDistanceOfLocation(space.getLocation(), this.location);
+    return getDistanceOfLocation(space.location, this.location);
   }
 
   /**
@@ -87,7 +87,7 @@ class Position {
    */
   getRelativeDirectionOf(space) {
     return getRelativeDirection(
-      getDirectionOfLocation(space.getLocation(), this.location),
+      getDirectionOfLocation(space.location, this.location),
       this.orientation,
     );
   }

--- a/packages/warriorjs-core/src/Position.test.js
+++ b/packages/warriorjs-core/src/Position.test.js
@@ -30,7 +30,7 @@ describe('Position', () => {
   });
 
   test('returns the space at its location', () => {
-    expect(position.getSpace().getLocation()).toEqual(position.location);
+    expect(position.getSpace().location).toEqual(position.location);
   });
 
   test('gets relative space in front', () => {

--- a/packages/warriorjs-core/src/Unit.js
+++ b/packages/warriorjs-core/src/Unit.js
@@ -1,4 +1,5 @@
 import Logger from './Logger';
+import Space from './Space';
 
 /** Class representing a unit. */
 class Unit {
@@ -315,6 +316,19 @@ class Unit {
   }
 
   /**
+   * Returns the sensed space located at the direction and number of spaces.
+   *
+   * @param {string} direction The direction.
+   * @param {number} forward The number of spaces forward.
+   * @param {number} right The number of spaces to the right.
+   *
+   * @returns {SensedSpace} The sensed space.
+   */
+  getSensedSpaceAt(direction, forward = 1, right = 0) {
+    return this.getSpaceAt(direction, forward, right).as(this);
+  }
+
+  /**
    * Returns the space located at the direction and number of spaces.
    *
    * @param {string} direction The direction.
@@ -333,28 +347,32 @@ class Unit {
    * @returns {string} The relative direction of the stairs.
    */
   getDirectionOfStairs() {
-    return this.getDirectionOf(this.position.floor.getStairsSpace());
+    return this.position.getRelativeDirectionOf(
+      this.position.floor.getStairsSpace(),
+    );
   }
 
   /**
-   * Returns the direction of the given space with reference to this unit.
+   * Returns the direction of the given space, with reference to this unit.
    *
-   * @param {Space} space The space to get the direction of.
+   * @param {SensedSpace} sensedSpace The space to get the direction of.
    *
    * @returns {string} The relative direction of the space.
    */
-  getDirectionOf(space) {
+  getDirectionOf(sensedSpace) {
+    const space = Space.from(sensedSpace, this);
     return this.position.getRelativeDirectionOf(space);
   }
 
   /**
    * Returns the distance between the given space and this unit.
    *
-   * @param {Space} space The space to calculate the distance of.
+   * @param {SensedSpace} sensedSpace The space to calculate the distance of.
    *
    * @returns {number} The distance of the space.
    */
-  getDistanceOf(space) {
+  getDistanceOf(sensedSpace) {
+    const space = Space.from(sensedSpace, this);
     return this.position.getDistanceOf(space);
   }
 
@@ -398,20 +416,19 @@ class Unit {
   }
 
   /**
-   * Returns the player object for this unit.
+   * Returns this unit as sensed by the given unit.
    *
-   * The player object has the subset of the unit methods that belong to the
-   * Player API.
+   * @param {Unit} unit The unit sensing this unit.
    *
-   * @returns {object} The player object.
+   * @returns {SensedUnit} The sensed unit.
    */
-  toPlayerObject() {
+  as() {
     return {
-      isHostile: this.isHostile.bind(this),
+      isBound: this.isBound.bind(this),
       isFriendly: this.isFriendly.bind(this),
+      isHostile: this.isHostile.bind(this),
       isPlayer: this.isPlayer.bind(this),
       isWarrior: this.isWarrior.bind(this),
-      isBound: this.isBound.bind(this),
       isUnderEffect: this.isUnderEffect.bind(this),
     };
   }

--- a/packages/warriorjs-core/src/Unit.js
+++ b/packages/warriorjs-core/src/Unit.js
@@ -10,7 +10,7 @@ class Unit {
    * @param {string} character The character of the unit.
    * @param {number} maxHealth The max health in HP.
    * @param {number} reward The number of points to reward when killed.
-   * @param {boolean} hostile Whether the unit is hostile or not.
+   * @param {boolean} enemy Whether the unit is an enemy or not.
    * @param {boolean} bound Whether the unit is bound or not.
    */
   constructor(
@@ -18,14 +18,14 @@ class Unit {
     character,
     maxHealth,
     reward = null,
-    hostile = true,
+    enemy = true,
     bound = false,
   ) {
     this.name = name;
     this.character = character;
     this.maxHealth = maxHealth;
     this.reward = reward === null ? maxHealth : reward;
-    this.hostile = hostile;
+    this.enemy = enemy;
     this.bound = bound;
     this.abilities = new Map();
     this.effects = new Map();
@@ -185,7 +185,7 @@ class Unit {
   damage(receiver, amount) {
     receiver.takeDamage(amount);
     if (!receiver.isAlive()) {
-      if (receiver.as(this).isHostile()) {
+      if (receiver.as(this).isEnemy()) {
         this.earnPoints(receiver.reward);
       } else {
         this.losePoints(receiver.reward);
@@ -211,7 +211,7 @@ class Unit {
    */
   release(receiver) {
     receiver.unbind();
-    if (!receiver.as(this).isHostile()) {
+    if (!receiver.as(this).isEnemy()) {
       receiver.vanish();
       this.earnPoints(receiver.reward);
     }
@@ -387,7 +387,7 @@ class Unit {
   as(unit) {
     return {
       isBound: this.isBound.bind(this),
-      isHostile: () => this.hostile !== unit.hostile,
+      isEnemy: () => this.enemy !== unit.enemy,
       isUnderEffect: this.isUnderEffect.bind(this),
     };
   }

--- a/packages/warriorjs-core/src/Unit.js
+++ b/packages/warriorjs-core/src/Unit.js
@@ -185,7 +185,7 @@ class Unit {
   damage(receiver, amount) {
     receiver.takeDamage(amount);
     if (!receiver.isAlive()) {
-      if (receiver.isHostile()) {
+      if (receiver.as(this).isHostile()) {
         this.earnPoints(receiver.reward);
       } else {
         this.losePoints(receiver.reward);
@@ -205,51 +205,13 @@ class Unit {
   }
 
   /**
-   * Checks if the unit is hostile.
-   *
-   * A bound unit is not considered hostile.
-   *
-   * @returns {boolean} Whether the unit is hostile or not.
-   */
-  isHostile() {
-    return this.hostile && !this.bound;
-  }
-
-  /**
-   * Checks if the unit is friendly.
-   *
-   * @returns {boolean} Whether the unit is friendly or not.
-   */
-  isFriendly() {
-    return !this.hostile;
-  }
-
-  /**
-   * Checks if the unit is controlled by the player.
-   *
-   * @returns {boolean} Whether the unit is controlled by the player or not.
-   */
-  isPlayer() {
-    return this.isWarrior();
-  }
-
-  /**
-   * Checks if the unit is the warrior.
-   *
-   * @returns {boolean} Whether the unit is the warrior or not.
-   */
-  isWarrior() {
-    return this.constructor.name === 'Warrior';
-  }
-
-  /**
    * Unbinds another unit.
    *
    * @param {Unit} receiver The unit to unbind.
    */
   release(receiver) {
     receiver.unbind();
-    if (receiver.isFriendly()) {
+    if (!receiver.as(this).isHostile()) {
       receiver.vanish();
       this.earnPoints(receiver.reward);
     }
@@ -422,13 +384,10 @@ class Unit {
    *
    * @returns {SensedUnit} The sensed unit.
    */
-  as() {
+  as(unit) {
     return {
       isBound: this.isBound.bind(this),
-      isFriendly: this.isFriendly.bind(this),
-      isHostile: this.isHostile.bind(this),
-      isPlayer: this.isPlayer.bind(this),
-      isWarrior: this.isWarrior.bind(this),
+      isHostile: () => this.hostile !== unit.hostile,
       isUnderEffect: this.isUnderEffect.bind(this),
     };
   }
@@ -453,7 +412,7 @@ class Unit {
       character: this.character,
       maxHealth: this.maxHealth,
       health: this.health,
-      warrior: this.isWarrior(),
+      warrior: this.constructor.name === 'Warrior',
     };
   }
 }

--- a/packages/warriorjs-core/src/Unit.test.js
+++ b/packages/warriorjs-core/src/Unit.test.js
@@ -43,8 +43,8 @@ describe('Unit', () => {
     });
   });
 
-  test('has a hostile status which defaults to true', () => {
-    expect(unit.hostile).toBe(true);
+  test('has an enemy status which defaults to true', () => {
+    expect(unit.enemy).toBe(true);
   });
 
   test('has a bound status which defaults to false', () => {
@@ -277,7 +277,7 @@ describe('Unit', () => {
       receiver.reward = 10;
       receiver.health = 5;
       receiver.position = {};
-      receiver.as = () => ({ isHostile: () => true });
+      receiver.as = () => ({ isEnemy: () => true });
       receiver.log = jest.fn();
     });
 
@@ -294,7 +294,7 @@ describe('Unit', () => {
     });
 
     test('lose points equal to reward when killing a friend', () => {
-      receiver.as = () => ({ isHostile: () => false });
+      receiver.as = () => ({ isEnemy: () => false });
       unit.losePoints = jest.fn();
       unit.damage(receiver, 5);
       expect(unit.losePoints).toHaveBeenCalledWith(10);
@@ -318,7 +318,7 @@ describe('Unit', () => {
       receiver.reward = 10;
       receiver.bound = true;
       receiver.position = {};
-      receiver.as = () => ({ isHostile: () => true });
+      receiver.as = () => ({ isEnemy: () => true });
       receiver.log = jest.fn();
     });
 
@@ -336,7 +336,7 @@ describe('Unit', () => {
 
     describe('friendly unit', () => {
       beforeEach(() => {
-        receiver.as = () => ({ isHostile: () => false });
+        receiver.as = () => ({ isEnemy: () => false });
       });
 
       test('vanishes the unit', () => {
@@ -506,20 +506,20 @@ describe('Unit', () => {
 
     beforeEach(() => {
       sensingUnit = new Unit();
-      sensingUnit.hostile = false;
+      sensingUnit.enemy = false;
       floor.addUnit(sensingUnit, { x: 0, y: 1, facing: SOUTH });
       sensedUnit = unit.as(sensingUnit);
     });
 
     test('allows calling sensed unit methods', () => {
-      const allowedApi = ['isBound', 'isHostile', 'isUnderEffect'];
+      const allowedApi = ['isBound', 'isEnemy', 'isUnderEffect'];
       allowedApi.forEach(propertyName => {
         sensedUnit[propertyName]();
       });
     });
 
-    test("is considered hostile if it doesn't fight for the same side", () => {
-      expect(sensedUnit.isHostile()).toBe(true);
+    test("is considered enemy if it doesn't fight for the same side", () => {
+      expect(sensedUnit.isEnemy()).toBe(true);
     });
 
     test("doesn't allow calling other unit methods", () => {

--- a/packages/warriorjs-core/src/getLevel.test.js
+++ b/packages/warriorjs-core/src/getLevel.test.js
@@ -63,7 +63,7 @@ const levelConfig = {
         feel: unit => ({
           description: `Return the adjacent space in the given direction (${FORWARD} by default).`,
           perform(direction = FORWARD) {
-            return unit.getSpaceAt(direction);
+            return unit.getSensedSpaceAt(direction);
           },
         }),
       },
@@ -97,7 +97,7 @@ const levelConfig = {
           feel: unit => ({
             description: `Return the adjacent space in the given direction (${FORWARD} by default).`,
             perform(direction = FORWARD) {
-              return unit.getSpaceAt(direction);
+              return unit.getSensedSpaceAt(direction);
             },
           }),
         },

--- a/packages/warriorjs-core/src/getLevel.test.js
+++ b/packages/warriorjs-core/src/getLevel.test.js
@@ -1,10 +1,4 @@
-import {
-  BACKWARD,
-  EAST,
-  FORWARD,
-  RELATIVE_DIRECTIONS,
-  WEST,
-} from '@warriorjs/geography';
+import { EAST, FORWARD, RELATIVE_DIRECTIONS, WEST } from '@warriorjs/geography';
 
 import getLevel from './getLevel';
 
@@ -32,39 +26,16 @@ const levelConfig = {
       character: '@',
       maxHealth: 20,
       abilities: {
-        walk: unit => ({
+        walk: () => ({
           action: true,
           description: `Move one space in the given direction (${FORWARD} by default).`,
-          perform(direction = FORWARD) {
-            unit.log(`walks ${direction}`);
-            const space = unit.getSpaceAt(direction);
-            if (space.isEmpty()) {
-              unit.move(direction);
-            } else {
-              unit.log(`bumps into ${space}`);
-            }
-          },
         }),
-        attack: unit => ({
+        attack: () => ({
           action: true,
           description: `Attack a unit in the given direction (${FORWARD} by default) dealing 5 HP of damage.`,
-          perform(direction = FORWARD) {
-            const receiver = unit.getSpaceAt(direction).getUnit();
-            if (receiver) {
-              unit.log(`attacks ${direction} and hits ${receiver}`);
-              const attackingBackward = direction === BACKWARD;
-              const amount = attackingBackward ? 3 : 5;
-              unit.damage(receiver, amount);
-            } else {
-              unit.log(`attacks ${direction} and hits nothing`);
-            }
-          },
         }),
-        feel: unit => ({
+        feel: () => ({
           description: `Return the adjacent space in the given direction (${FORWARD} by default).`,
-          perform(direction = FORWARD) {
-            return unit.getSensedSpaceAt(direction);
-          },
         }),
       },
       position: {
@@ -79,26 +50,12 @@ const levelConfig = {
         character: 's',
         maxHealth: 12,
         abilities: {
-          attack: unit => ({
+          attack: () => ({
             action: true,
             description: `Attack a unit in the given direction (${FORWARD} by default) dealing 3 HP of damage.`,
-            perform(direction = FORWARD) {
-              const receiver = unit.getSpaceAt(direction).getUnit();
-              if (receiver) {
-                unit.log(`attacks ${direction} and hits ${receiver}`);
-                const attackingBackward = direction === BACKWARD;
-                const amount = attackingBackward ? 2 : 3;
-                unit.damage(receiver, amount);
-              } else {
-                unit.log(`attacks ${direction} and hits nothing`);
-              }
-            },
           }),
-          feel: unit => ({
+          feel: () => ({
             description: `Return the adjacent space in the given direction (${FORWARD} by default).`,
-            perform(direction = FORWARD) {
-              return unit.getSensedSpaceAt(direction);
-            },
           }),
         },
         playTurn(sludge) {

--- a/packages/warriorjs-core/src/runLevel.test.js
+++ b/packages/warriorjs-core/src/runLevel.test.js
@@ -91,7 +91,7 @@ const levelConfig = {
         playTurn(sludge) {
           const threatDirection = RELATIVE_DIRECTIONS.find(direction => {
             const unit = sludge.feel(direction).getUnit();
-            return unit && unit.isHostile() && !unit.isBound();
+            return unit && unit.isEnemy() && !unit.isBound();
           });
           if (threatDirection) {
             sludge.attack(threatDirection);
@@ -112,7 +112,7 @@ test('passes level with a winner player code', () => {
     class Player {
       playTurn(warrior) {
         const spaceAhead = warrior.feel();
-        if (spaceAhead.isUnit() && spaceAhead.getUnit().isHostile()) {
+        if (spaceAhead.isUnit() && spaceAhead.getUnit().isEnemy()) {
           warrior.attack();
         } else {
           warrior.walk();

--- a/packages/warriorjs-core/src/runLevel.test.js
+++ b/packages/warriorjs-core/src/runLevel.test.js
@@ -52,7 +52,7 @@ const levelConfig = {
         }),
         feel: unit => ({
           perform(direction = FORWARD) {
-            return unit.getSpaceAt(direction);
+            return unit.getSensedSpaceAt(direction);
           },
         }),
       },
@@ -84,7 +84,7 @@ const levelConfig = {
           }),
           feel: unit => ({
             perform(direction = FORWARD) {
-              return unit.getSpaceAt(direction);
+              return unit.getSensedSpaceAt(direction);
             },
           }),
         },
@@ -112,7 +112,7 @@ test('passes level with a winner player code', () => {
     class Player {
       playTurn(warrior) {
         const spaceAhead = warrior.feel();
-        if (spaceAhead.isUnit() && spaceAhead.getUnit().isHostile()) {
+        if (spaceAhead.isUnit() && spaceAhead.getUnit().isEnemy()) {
           warrior.attack();
         } else {
           warrior.walk();

--- a/packages/warriorjs-core/src/runLevel.test.js
+++ b/packages/warriorjs-core/src/runLevel.test.js
@@ -89,12 +89,12 @@ const levelConfig = {
           }),
         },
         playTurn(sludge) {
-          const playerDirection = RELATIVE_DIRECTIONS.find(direction => {
-            const space = sludge.feel(direction);
-            return space.isUnit() && space.getUnit().isPlayer();
+          const threatDirection = RELATIVE_DIRECTIONS.find(direction => {
+            const unit = sludge.feel(direction).getUnit();
+            return unit && unit.isHostile() && !unit.isBound();
           });
-          if (playerDirection) {
-            sludge.attack(playerDirection);
+          if (threatDirection) {
+            sludge.attack(threatDirection);
           }
         },
         position: {
@@ -112,7 +112,7 @@ test('passes level with a winner player code', () => {
     class Player {
       playTurn(warrior) {
         const spaceAhead = warrior.feel();
-        if (spaceAhead.isUnit() && spaceAhead.getUnit().isEnemy()) {
+        if (spaceAhead.isUnit() && spaceAhead.getUnit().isHostile()) {
           warrior.attack();
         } else {
           warrior.walk();

--- a/packages/warriorjs-tower-beginner/src/index.js
+++ b/packages/warriorjs-tower-beginner/src/index.js
@@ -218,7 +218,7 @@ export default {
     {
       description: 'You hear cries for help. Captives must need rescuing.',
       tip:
-        "Once you find a unit, use `unit.isFriendly() && unit.isBound()` to see if there's a captive and `warrior.rescue()` to rescue him. Don't attack captives.",
+        "When you find a unit, use `!unit.isHostile() && unit.isBound()` to see if he's a captive and `warrior.rescue()` to rescue him. Don't attack captives.",
       clue:
         "Don't forget to constantly check if you are being attacked. Rest until your health is full if you're not taking damage.",
       timeBonus: 45,

--- a/packages/warriorjs-tower-beginner/src/index.js
+++ b/packages/warriorjs-tower-beginner/src/index.js
@@ -218,7 +218,7 @@ export default {
     {
       description: 'You hear cries for help. Captives must need rescuing.',
       tip:
-        "When you find a unit, use `!unit.isHostile() && unit.isBound()` to see if he's a captive and `warrior.rescue()` to rescue him. Don't attack captives.",
+        "When you find a unit, use `!unit.isEnemy() && unit.isBound()` to see if he's a captive and `warrior.rescue()` to rescue him. Don't attack captives.",
       clue:
         "Don't forget to constantly check if you are being attacked. Rest until your health is full if you're not taking damage.",
       timeBonus: 45,

--- a/packages/warriorjs-tower-intermediate/src/index.js
+++ b/packages/warriorjs-tower-intermediate/src/index.js
@@ -115,10 +115,9 @@ export default {
     },
     {
       description: 'You feel slime on all sides, you are surrounded!',
-      tip:
-        'Call `warrior.bind()` to bind an enemy to keep him from attacking. Bound enemies no longer look like enemies.',
+      tip: 'Call `warrior.bind()` to bind an enemy to keep him from attacking.',
       clue:
-        'Count the number of enemies around you. Bind an enemy if there are two or more.',
+        'Count the number of unbound enemies around you. Bind an enemy if there are two or more.',
       timeBonus: 50,
       aceScore: 101,
       floor: {
@@ -184,7 +183,7 @@ export default {
       tip:
         "Use `warrior.listen()` to find spaces with other units, and `warrior.directionOf()` to determine what direction they're in.",
       clue:
-        'Walk towards an enemy or captive with `warrior.walk(warrior.directionOf(warrior.listen()[0]))`. Once `warrior.listen().length === 0`, head for the stairs.',
+        'Walk towards a unit with `warrior.walk(warrior.directionOf(warrior.listen()[0]))`. Once `warrior.listen().length === 0`, head for the stairs.',
       timeBonus: 55,
       aceScore: 144,
       floor: {

--- a/packages/warriorjs-tower-intermediate/src/index.js
+++ b/packages/warriorjs-tower-intermediate/src/index.js
@@ -59,7 +59,7 @@ export default {
       tip:
         'Just like walking, you can attack and feel in multiple directions (forward, left, right, backward).',
       clue:
-        "Call `warrior.feel().isUnit()` and `unit.isHostile()` in each direction to make sure there isn't an enemy beside you (attack if there is). Call `warrior.rest()` if you're low in health when there are no enemies around.",
+        "Call `warrior.feel().isUnit()` and `unit.isEnemy()` in each direction to make sure there isn't an enemy beside you (attack if there is). Call `warrior.rest()` if you're low in health when there are no enemies around.",
       timeBonus: 40,
       aceScore: 84,
       floor: {

--- a/packages/warriorjs-units/src/Archer.js
+++ b/packages/warriorjs-units/src/Archer.js
@@ -10,14 +10,18 @@ const Archer = {
     shoot: shoot({ range: 3, power: 3 }),
   },
   playTurn(archer) {
-    const playerDirection = RELATIVE_DIRECTIONS.find(direction => {
+    const threatDirection = RELATIVE_DIRECTIONS.find(direction => {
       const spaceWithUnit = archer
         .look(direction)
         .find(space => space.isUnit());
-      return spaceWithUnit && spaceWithUnit.getUnit().isPlayer();
+      return (
+        spaceWithUnit &&
+        spaceWithUnit.getUnit().isHostile() &&
+        !spaceWithUnit.getUnit().isBound()
+      );
     });
-    if (playerDirection) {
-      archer.shoot(playerDirection);
+    if (threatDirection) {
+      archer.shoot(threatDirection);
     }
   },
 };

--- a/packages/warriorjs-units/src/Archer.js
+++ b/packages/warriorjs-units/src/Archer.js
@@ -16,7 +16,7 @@ const Archer = {
         .find(space => space.isUnit());
       return (
         spaceWithUnit &&
-        spaceWithUnit.getUnit().isHostile() &&
+        spaceWithUnit.getUnit().isEnemy() &&
         !spaceWithUnit.getUnit().isBound()
       );
     });

--- a/packages/warriorjs-units/src/Archer.test.js
+++ b/packages/warriorjs-units/src/Archer.test.js
@@ -54,7 +54,7 @@ describe('Archer', () => {
         space,
         {
           isUnit: () => true,
-          getUnit: () => ({ isHostile: () => false }),
+          getUnit: () => ({ isEnemy: () => false }),
         },
         anotherSpace,
       ]);
@@ -69,7 +69,7 @@ describe('Archer', () => {
           isUnit: () => true,
           getUnit: () => ({
             isBound: () => false,
-            isHostile: () => true,
+            isEnemy: () => true,
           }),
         },
         space,
@@ -90,7 +90,7 @@ describe('Archer', () => {
           isUnit: () => true,
           getUnit: () => ({
             isBound: () => true,
-            isHostile: () => true,
+            isEnemy: () => true,
           }),
         },
       ]);

--- a/packages/warriorjs-units/src/Archer.test.js
+++ b/packages/warriorjs-units/src/Archer.test.js
@@ -54,7 +54,7 @@ describe('Archer', () => {
         space,
         {
           isUnit: () => true,
-          getUnit: () => ({ isPlayer: () => false }),
+          getUnit: () => ({ isHostile: () => false }),
         },
         anotherSpace,
       ]);
@@ -62,12 +62,15 @@ describe('Archer', () => {
       expect(anotherSpace.isUnit).not.toHaveBeenCalled();
     });
 
-    test('stops looking if it finds player', () => {
+    test('stops looking if it finds threat', () => {
       turn.look.mockReturnValueOnce([space, space, space]).mockReturnValueOnce([
         space,
         {
           isUnit: () => true,
-          getUnit: () => ({ isPlayer: () => true }),
+          getUnit: () => ({
+            isBound: () => false,
+            isHostile: () => true,
+          }),
         },
         space,
       ]);
@@ -79,13 +82,16 @@ describe('Archer', () => {
       expect(turn.shoot).toHaveBeenCalledWith(RIGHT);
     });
 
-    test("does nothing if it doesn't find player", () => {
+    test("does nothing if it doesn't find threat", () => {
       turn.look.mockReturnValueOnce([
         space,
         space,
         {
           isUnit: () => true,
-          getUnit: () => ({ isPlayer: () => false }),
+          getUnit: () => ({
+            isBound: () => true,
+            isHostile: () => true,
+          }),
         },
       ]);
       Archer.playTurn(turn);

--- a/packages/warriorjs-units/src/Captive.js
+++ b/packages/warriorjs-units/src/Captive.js
@@ -3,7 +3,7 @@ const Captive = {
   character: 'C',
   maxHealth: 1,
   reward: 20,
-  hostile: false,
+  enemy: false,
   bound: true,
   playTurn() {},
 };

--- a/packages/warriorjs-units/src/Captive.test.js
+++ b/packages/warriorjs-units/src/Captive.test.js
@@ -13,8 +13,8 @@ describe('Captive', () => {
     expect(Captive.reward).toBe(20);
   });
 
-  test('is not hostile', () => {
-    expect(Captive.hostile).toBe(false);
+  test('is not an enemy', () => {
+    expect(Captive.enemy).toBe(false);
   });
 
   test('is bound', () => {

--- a/packages/warriorjs-units/src/Sludge.js
+++ b/packages/warriorjs-units/src/Sludge.js
@@ -12,7 +12,7 @@ const Sludge = {
   playTurn(sludge) {
     const threatDirection = RELATIVE_DIRECTIONS.find(direction => {
       const unit = sludge.feel(direction).getUnit();
-      return unit && unit.isHostile() && !unit.isBound();
+      return unit && unit.isEnemy() && !unit.isBound();
     });
     if (threatDirection) {
       sludge.attack(threatDirection);

--- a/packages/warriorjs-units/src/Sludge.js
+++ b/packages/warriorjs-units/src/Sludge.js
@@ -10,12 +10,12 @@ const Sludge = {
     feel: feel(),
   },
   playTurn(sludge) {
-    const playerDirection = RELATIVE_DIRECTIONS.find(direction => {
-      const space = sludge.feel(direction);
-      return space.isUnit() && space.getUnit().isPlayer();
+    const threatDirection = RELATIVE_DIRECTIONS.find(direction => {
+      const unit = sludge.feel(direction).getUnit();
+      return unit && unit.isHostile() && !unit.isBound();
     });
-    if (playerDirection) {
-      sludge.attack(playerDirection);
+    if (threatDirection) {
+      sludge.attack(threatDirection);
     }
   },
 };

--- a/packages/warriorjs-units/src/Sludge.test.js
+++ b/packages/warriorjs-units/src/Sludge.test.js
@@ -54,7 +54,7 @@ describe('Sludge', () => {
         .mockReturnValueOnce({
           getUnit: () => ({
             isBound: () => false,
-            isHostile: () => true,
+            isEnemy: () => true,
           }),
         });
       Sludge.playTurn(turn);

--- a/packages/warriorjs-units/src/Sludge.test.js
+++ b/packages/warriorjs-units/src/Sludge.test.js
@@ -33,7 +33,7 @@ describe('Sludge', () => {
     let space;
 
     beforeEach(() => {
-      space = { isUnit: () => false };
+      space = { getUnit: () => undefined };
       turn = {
         attack: jest.fn(),
         feel: jest.fn(() => space),
@@ -48,12 +48,14 @@ describe('Sludge', () => {
       expect(turn.feel).toHaveBeenCalledWith(LEFT);
     });
 
-    test('stops looking if it finds player', () => {
+    test('stops looking if it finds threat', () => {
       turn.feel
-        .mockReturnValueOnce({ isUnit: () => false })
+        .mockReturnValueOnce({ getUnit: () => undefined })
         .mockReturnValueOnce({
-          isUnit: () => true,
-          getUnit: () => ({ isPlayer: () => true }),
+          getUnit: () => ({
+            isBound: () => false,
+            isHostile: () => true,
+          }),
         });
       Sludge.playTurn(turn);
       expect(turn.feel).toHaveBeenCalledWith(FORWARD);
@@ -63,7 +65,7 @@ describe('Sludge', () => {
       expect(turn.attack).toHaveBeenCalledWith(RIGHT);
     });
 
-    test("does nothing if it doesn't find player", () => {
+    test("does nothing if it doesn't find threat", () => {
       Sludge.playTurn(turn);
       expect(turn.attack).not.toHaveBeenCalled();
     });

--- a/packages/warriorjs-units/src/ThickSludge.test.js
+++ b/packages/warriorjs-units/src/ThickSludge.test.js
@@ -33,7 +33,7 @@ describe('ThickSludge', () => {
     let space;
 
     beforeEach(() => {
-      space = { isUnit: () => false };
+      space = { getUnit: () => undefined };
       turn = {
         attack: jest.fn(),
         feel: jest.fn(() => space),
@@ -48,12 +48,14 @@ describe('ThickSludge', () => {
       expect(turn.feel).toHaveBeenCalledWith(LEFT);
     });
 
-    test('stops looking if it finds player', () => {
+    test('stops looking if it finds threat', () => {
       turn.feel
-        .mockReturnValueOnce({ isUnit: () => false })
+        .mockReturnValueOnce({ getUnit: () => undefined })
         .mockReturnValueOnce({
-          isUnit: () => true,
-          getUnit: () => ({ isPlayer: () => true }),
+          getUnit: () => ({
+            isBound: () => false,
+            isHostile: () => true,
+          }),
         });
       ThickSludge.playTurn(turn);
       expect(turn.feel).toHaveBeenCalledWith(FORWARD);
@@ -63,7 +65,7 @@ describe('ThickSludge', () => {
       expect(turn.attack).toHaveBeenCalledWith(RIGHT);
     });
 
-    test("does nothing if it doesn't find player", () => {
+    test("does nothing if it doesn't find threat", () => {
       ThickSludge.playTurn(turn);
       expect(turn.attack).not.toHaveBeenCalled();
     });

--- a/packages/warriorjs-units/src/ThickSludge.test.js
+++ b/packages/warriorjs-units/src/ThickSludge.test.js
@@ -54,7 +54,7 @@ describe('ThickSludge', () => {
         .mockReturnValueOnce({
           getUnit: () => ({
             isBound: () => false,
-            isHostile: () => true,
+            isEnemy: () => true,
           }),
         });
       ThickSludge.playTurn(turn);

--- a/packages/warriorjs-units/src/Wizard.test.js
+++ b/packages/warriorjs-units/src/Wizard.test.js
@@ -54,7 +54,7 @@ describe('Wizard', () => {
         space,
         {
           isUnit: () => true,
-          getUnit: () => ({ isHostile: () => false }),
+          getUnit: () => ({ isEnemy: () => false }),
         },
         anotherSpace,
       ]);
@@ -69,7 +69,7 @@ describe('Wizard', () => {
           isUnit: () => true,
           getUnit: () => ({
             isBound: () => false,
-            isHostile: () => true,
+            isEnemy: () => true,
           }),
         },
         space,
@@ -90,7 +90,7 @@ describe('Wizard', () => {
           isUnit: () => true,
           getUnit: () => ({
             isBound: () => true,
-            isHostile: () => true,
+            isEnemy: () => true,
           }),
         },
       ]);

--- a/packages/warriorjs-units/src/Wizard.test.js
+++ b/packages/warriorjs-units/src/Wizard.test.js
@@ -54,7 +54,7 @@ describe('Wizard', () => {
         space,
         {
           isUnit: () => true,
-          getUnit: () => ({ isPlayer: () => false }),
+          getUnit: () => ({ isHostile: () => false }),
         },
         anotherSpace,
       ]);
@@ -62,12 +62,15 @@ describe('Wizard', () => {
       expect(anotherSpace.isUnit).not.toHaveBeenCalled();
     });
 
-    test('stops looking if it finds player', () => {
+    test('stops looking if it finds threat', () => {
       turn.look.mockReturnValueOnce([space, space, space]).mockReturnValueOnce([
         space,
         {
           isUnit: () => true,
-          getUnit: () => ({ isPlayer: () => true }),
+          getUnit: () => ({
+            isBound: () => false,
+            isHostile: () => true,
+          }),
         },
         space,
       ]);
@@ -79,13 +82,16 @@ describe('Wizard', () => {
       expect(turn.shoot).toHaveBeenCalledWith(RIGHT);
     });
 
-    test("does nothing if it doesn't find player", () => {
+    test("does nothing if it doesn't find threat", () => {
       turn.look.mockReturnValueOnce([
         space,
         space,
         {
           isUnit: () => true,
-          getUnit: () => ({ isPlayer: () => false }),
+          getUnit: () => ({
+            isBound: () => true,
+            isHostile: () => true,
+          }),
         },
       ]);
       Wizard.playTurn(turn);


### PR DESCRIPTION
This PR introduces the entities `SensedSpace` and `SensedUnit`. Whenever a unit gets a space after sensing an area, one or multiple `SensedSpace` will be returned. This new object represents the space as it was perceived by the unit that sensed it. If there was a unit located at the space, that unit will be a `SensedUnit`. Methods called on these sensed entities are now be relative to the unit that sensed them:

* `space.getLocation()`: returns the location of the space as the number of spaces forward and to the right of the unit that sensed it.
* `unit.isEnemy()`: returns whether the unit is considered an enemy by the unit that sensed it.