### PR TITLE
Rename say to log

### DIFF
--- a/packages/warriorjs-abilities/src/attack.js
+++ b/packages/warriorjs-abilities/src/attack.js
@@ -9,12 +9,12 @@ function attack({ power }) {
     perform(direction = defaultDirection) {
       const receiver = unit.getSpaceAt(direction).getUnit();
       if (receiver) {
-        unit.say(`attacks ${direction} and hits ${receiver}`);
+        unit.log(`attacks ${direction} and hits ${receiver}`);
         const attackingBackward = direction === BACKWARD;
         const amount = attackingBackward ? Math.ceil(power / 2.0) : power;
         unit.damage(receiver, amount);
       } else {
-        unit.say(`attacks ${direction} and hits nothing`);
+        unit.log(`attacks ${direction} and hits nothing`);
       }
     },
   });

--- a/packages/warriorjs-abilities/src/attack.test.js
+++ b/packages/warriorjs-abilities/src/attack.test.js
@@ -9,7 +9,7 @@ describe('attack', () => {
   beforeEach(() => {
     unit = {
       damage: jest.fn(),
-      say: jest.fn(),
+      log: jest.fn(),
     };
     attack = attackCreator({ power: 3 })(unit);
   });
@@ -40,7 +40,7 @@ describe('attack', () => {
     test('misses if no receiver', () => {
       unit.getSpaceAt = () => ({ getUnit: () => null });
       attack.perform();
-      expect(unit.say).toHaveBeenCalledWith(
+      expect(unit.log).toHaveBeenCalledWith(
         `attacks ${FORWARD} and hits nothing`,
       );
       expect(unit.damage).not.toHaveBeenCalled();
@@ -53,7 +53,7 @@ describe('attack', () => {
 
       test('damages receiver', () => {
         attack.perform();
-        expect(unit.say).toHaveBeenCalledWith(
+        expect(unit.log).toHaveBeenCalledWith(
           `attacks ${FORWARD} and hits receiver`,
         );
         expect(unit.damage).toHaveBeenCalledWith('receiver', 3);
@@ -61,7 +61,7 @@ describe('attack', () => {
 
       test('reduces power when attacking backward', () => {
         attack.perform(BACKWARD);
-        expect(unit.say).toHaveBeenCalledWith(
+        expect(unit.log).toHaveBeenCalledWith(
           `attacks ${BACKWARD} and hits receiver`,
         );
         expect(unit.damage).toHaveBeenCalledWith('receiver', 2);

--- a/packages/warriorjs-abilities/src/bind.js
+++ b/packages/warriorjs-abilities/src/bind.js
@@ -9,10 +9,10 @@ function bind() {
     perform(direction = defaultDirection) {
       const receiver = unit.getSpaceAt(direction).getUnit();
       if (receiver) {
-        unit.say(`binds ${direction} and restricts ${receiver}`);
+        unit.log(`binds ${direction} and restricts ${receiver}`);
         receiver.bind();
       } else {
-        unit.say(`binds ${direction} and restricts nothing`);
+        unit.log(`binds ${direction} and restricts nothing`);
       }
     },
   });

--- a/packages/warriorjs-abilities/src/bind.test.js
+++ b/packages/warriorjs-abilities/src/bind.test.js
@@ -7,7 +7,7 @@ describe('bind', () => {
   let unit;
 
   beforeEach(() => {
-    unit = { say: jest.fn() };
+    unit = { log: jest.fn() };
     bind = bindCreator()(unit);
   });
 
@@ -37,7 +37,7 @@ describe('bind', () => {
     test('misses if no receiver', () => {
       unit.getSpaceAt = () => ({ getUnit: () => null });
       bind.perform();
-      expect(unit.say).toHaveBeenCalledWith(
+      expect(unit.log).toHaveBeenCalledWith(
         `binds ${FORWARD} and restricts nothing`,
       );
     });
@@ -55,7 +55,7 @@ describe('bind', () => {
 
       test('binds receiver', () => {
         bind.perform();
-        expect(unit.say).toHaveBeenCalledWith(
+        expect(unit.log).toHaveBeenCalledWith(
           `binds ${FORWARD} and restricts receiver`,
         );
         expect(receiver.bind).toHaveBeenCalled();

--- a/packages/warriorjs-abilities/src/detonate.js
+++ b/packages/warriorjs-abilities/src/detonate.js
@@ -8,7 +8,7 @@ function detonate({ targetPower, surroundingPower }) {
     action: true,
     description: `Detonate a bomb in a given direction (${defaultDirection} by default) dealing ${targetPower} HP of damage to that space and ${surroundingPower} HP of damage to surrounding 4 spaces (including yourself).`,
     perform(direction = defaultDirection) {
-      unit.say(`detonates a bomb ${direction} launching a deadly explosion`);
+      unit.log(`detonates a bomb ${direction} launching a deadly explosion`);
       const targetSpace = unit.getSpaceAt(direction);
       this.bomb(targetSpace, targetPower);
       surroundingOffsets
@@ -22,7 +22,7 @@ function detonate({ targetPower, surroundingPower }) {
       if (receiver) {
         unit.damage(receiver, power);
         if (receiver.isUnderEffect('ticking')) {
-          receiver.say(
+          receiver.log(
             "caught in bomb's flames which detonates ticking explosive",
           );
           receiver.triggerEffect('ticking');

--- a/packages/warriorjs-abilities/src/detonate.test.js
+++ b/packages/warriorjs-abilities/src/detonate.test.js
@@ -10,7 +10,7 @@ describe('detonate', () => {
     unit = {
       damage: jest.fn(),
       isUnderEffect: () => false,
-      say: jest.fn(),
+      log: jest.fn(),
     };
     detonate = detonateCreator({ targetPower: 4, surroundingPower: 2 })(unit);
   });
@@ -49,7 +49,7 @@ describe('detonate', () => {
         .mockReturnValueOnce({ getUnit: () => surroundingReceiver })
         .mockReturnValueOnce({ getUnit: () => unit });
       detonate.perform();
-      expect(unit.say).toHaveBeenCalledWith(
+      expect(unit.log).toHaveBeenCalledWith(
         `detonates a bomb ${FORWARD} launching a deadly explosion`,
       );
       expect(unit.getSpaceAt).toHaveBeenCalledWith(FORWARD);
@@ -66,14 +66,14 @@ describe('detonate', () => {
       const receiver = {
         isUnderEffect: () => true,
         triggerEffect: jest.fn(),
-        say: jest.fn(),
+        log: jest.fn(),
       };
       unit.getSpaceAt = jest
         .fn()
         .mockReturnValueOnce({ getUnit: () => receiver })
         .mockReturnValue({ getUnit: () => null });
       detonate.perform();
-      expect(receiver.say).toHaveBeenCalledWith(
+      expect(receiver.log).toHaveBeenCalledWith(
         "caught in bomb's flames which detonates ticking explosive",
       );
       expect(receiver.triggerEffect).toHaveBeenCalledWith('ticking');

--- a/packages/warriorjs-abilities/src/pivot.js
+++ b/packages/warriorjs-abilities/src/pivot.js
@@ -7,7 +7,7 @@ function pivot() {
     action: true,
     description: `Rotate in the given direction (${defaultDirection} by default).`,
     perform(direction = defaultDirection) {
-      unit.say(`pivots ${direction}`);
+      unit.log(`pivots ${direction}`);
       unit.rotate(direction);
     },
   });

--- a/packages/warriorjs-abilities/src/pivot.test.js
+++ b/packages/warriorjs-abilities/src/pivot.test.js
@@ -9,7 +9,7 @@ describe('pivot', () => {
   beforeEach(() => {
     unit = {
       rotate: jest.fn(),
-      say: jest.fn(),
+      log: jest.fn(),
     };
     pivot = pivotCreator()(unit);
   });
@@ -27,13 +27,13 @@ describe('pivot', () => {
   describe('performing', () => {
     test('flips around when not passing direction', () => {
       pivot.perform();
-      expect(unit.say).toHaveBeenCalledWith(`pivots ${BACKWARD}`);
+      expect(unit.log).toHaveBeenCalledWith(`pivots ${BACKWARD}`);
       expect(unit.rotate).toHaveBeenCalledWith(BACKWARD);
     });
 
     test('rotates in specified direction', () => {
       pivot.perform(RIGHT);
-      expect(unit.say).toHaveBeenCalledWith(`pivots ${RIGHT}`);
+      expect(unit.log).toHaveBeenCalledWith(`pivots ${RIGHT}`);
       expect(unit.rotate).toHaveBeenCalledWith(RIGHT);
     });
   });

--- a/packages/warriorjs-abilities/src/rescue.js
+++ b/packages/warriorjs-abilities/src/rescue.js
@@ -9,14 +9,14 @@ function rescue() {
     perform(direction = defaultDirection) {
       const receiver = unit.getSpaceAt(direction).getUnit();
       if (receiver && receiver.isBound()) {
-        unit.say(`unbinds ${direction} and rescues ${receiver}`);
+        unit.log(`unbinds ${direction} and rescues ${receiver}`);
         receiver.unbind();
         if (receiver.isFriendly()) {
           receiver.vanish();
           unit.earnPoints(receiver.reward);
         }
       } else {
-        unit.say(`unbinds ${direction} and rescues nothing`);
+        unit.log(`unbinds ${direction} and rescues nothing`);
       }
     },
   });

--- a/packages/warriorjs-abilities/src/rescue.test.js
+++ b/packages/warriorjs-abilities/src/rescue.test.js
@@ -9,7 +9,7 @@ describe('rescue', () => {
   beforeEach(() => {
     unit = {
       earnPoints: jest.fn(),
-      say: jest.fn(),
+      log: jest.fn(),
     };
     rescue = rescueCreator()(unit);
   });
@@ -40,7 +40,7 @@ describe('rescue', () => {
     test('misses if no receiver', () => {
       unit.getSpaceAt = () => ({ getUnit: () => null });
       rescue.perform();
-      expect(unit.say).toHaveBeenCalledWith(
+      expect(unit.log).toHaveBeenCalledWith(
         `unbinds ${FORWARD} and rescues nothing`,
       );
     });
@@ -63,14 +63,14 @@ describe('rescue', () => {
       test("does nothing to receiver if it's not bound", () => {
         receiver.isBound = () => false;
         rescue.perform();
-        expect(unit.say).toHaveBeenCalledWith(
+        expect(unit.log).toHaveBeenCalledWith(
           `unbinds ${FORWARD} and rescues nothing`,
         );
       });
 
       test('rescues receiver', () => {
         rescue.perform();
-        expect(unit.say).toHaveBeenCalledWith(
+        expect(unit.log).toHaveBeenCalledWith(
           `unbinds ${FORWARD} and rescues receiver`,
         );
         expect(receiver.unbind).toHaveBeenCalled();

--- a/packages/warriorjs-abilities/src/rest.js
+++ b/packages/warriorjs-abilities/src/rest.js
@@ -5,11 +5,11 @@ function rest({ healthGain }) {
     description: `Gain ${healthGainPercentage}% of max health back, but do nothing more.`,
     perform() {
       if (unit.health < unit.maxHealth) {
-        unit.say('rests');
+        unit.log('rests');
         const amount = Math.round(unit.maxHealth * healthGain);
         unit.heal(amount);
       } else {
-        unit.say('is already fit as a fiddle');
+        unit.log('is already fit as a fiddle');
       }
     },
   });

--- a/packages/warriorjs-abilities/src/rest.test.js
+++ b/packages/warriorjs-abilities/src/rest.test.js
@@ -9,7 +9,7 @@ describe('rest', () => {
       maxHealth: 20,
       health: 10,
       heal: jest.fn(),
-      say: jest.fn(),
+      log: jest.fn(),
     };
     rest = restCreator({ healthGain: 0.1 })(unit);
   });
@@ -27,14 +27,14 @@ describe('rest', () => {
   describe('performing', () => {
     test('gives health back', () => {
       rest.perform();
-      expect(unit.say).toHaveBeenCalledWith('rests');
+      expect(unit.log).toHaveBeenCalledWith('rests');
       expect(unit.heal).toHaveBeenCalledWith(2);
     });
 
     test("doesn't add health when at max", () => {
       unit.health = 20;
       rest.perform();
-      expect(unit.say).toHaveBeenCalledWith('is already fit as a fiddle');
+      expect(unit.log).toHaveBeenCalledWith('is already fit as a fiddle');
       expect(unit.heal).not.toHaveBeenCalled();
     });
   });

--- a/packages/warriorjs-abilities/src/shoot.js
+++ b/packages/warriorjs-abilities/src/shoot.js
@@ -12,10 +12,10 @@ function shoot({ power, range }) {
         .map(offset => unit.getSpaceAt(direction, offset).getUnit())
         .find(unitInRange => unitInRange);
       if (receiver) {
-        unit.say(`shoots ${direction} and hits ${receiver}`);
+        unit.log(`shoots ${direction} and hits ${receiver}`);
         unit.damage(receiver, power);
       } else {
-        unit.say(`shoots ${direction} and hits nothing`);
+        unit.log(`shoots ${direction} and hits nothing`);
       }
     },
   });

--- a/packages/warriorjs-abilities/src/shoot.test.js
+++ b/packages/warriorjs-abilities/src/shoot.test.js
@@ -9,7 +9,7 @@ describe('shoot', () => {
   beforeEach(() => {
     unit = {
       damage: jest.fn(),
-      say: jest.fn(),
+      log: jest.fn(),
     };
     shoot = shootCreator({ power: 3, range: 3 })(unit);
   });
@@ -49,7 +49,7 @@ describe('shoot', () => {
         .mockReturnValueOnce({ getUnit: () => null })
         .mockReturnValueOnce({ getUnit: () => 'anotherUnit' });
       shoot.perform();
-      expect(unit.say).toHaveBeenCalledWith(
+      expect(unit.log).toHaveBeenCalledWith(
         `shoots ${FORWARD} and hits nothing`,
       );
       expect(unit.damage).not.toHaveBeenCalled();
@@ -66,7 +66,7 @@ describe('shoot', () => {
 
       test('damages receiver', () => {
         shoot.perform();
-        expect(unit.say).toHaveBeenCalledWith(
+        expect(unit.log).toHaveBeenCalledWith(
           `shoots ${FORWARD} and hits receiver`,
         );
         expect(unit.damage).toHaveBeenCalledWith('receiver', 3);

--- a/packages/warriorjs-abilities/src/think.js
+++ b/packages/warriorjs-abilities/src/think.js
@@ -2,7 +2,7 @@ function think() {
   return unit => ({
     description: 'Think about your options before choosing an action.',
     perform(thought) {
-      unit.say(`thinks ${thought || 'nothing'}`);
+      unit.log(`thinks ${thought || 'nothing'}`);
     },
   });
 }

--- a/packages/warriorjs-abilities/src/think.test.js
+++ b/packages/warriorjs-abilities/src/think.test.js
@@ -5,7 +5,7 @@ describe('think', () => {
   let unit;
 
   beforeEach(() => {
-    unit = { say: jest.fn() };
+    unit = { log: jest.fn() };
     think = thinkCreator()(unit);
   });
 
@@ -22,12 +22,12 @@ describe('think', () => {
   describe('performing', () => {
     test('thinks nothing by default', () => {
       think.perform();
-      expect(unit.say).toHaveBeenCalledWith('thinks nothing');
+      expect(unit.log).toHaveBeenCalledWith('thinks nothing');
     });
 
     test('allows to specify thought', () => {
       think.perform('he should be brave');
-      expect(unit.say).toHaveBeenCalledWith('thinks he should be brave');
+      expect(unit.log).toHaveBeenCalledWith('thinks he should be brave');
     });
   });
 });

--- a/packages/warriorjs-abilities/src/walk.js
+++ b/packages/warriorjs-abilities/src/walk.js
@@ -7,12 +7,12 @@ function walk() {
     action: true,
     description: `Move one space in the given direction (${defaultDirection} by default).`,
     perform(direction = defaultDirection) {
-      unit.say(`walks ${direction}`);
+      unit.log(`walks ${direction}`);
       const space = unit.getSpaceAt(direction);
       if (space.isEmpty()) {
         unit.move(direction);
       } else {
-        unit.say(`bumps into ${space}`);
+        unit.log(`bumps into ${space}`);
       }
     },
   });

--- a/packages/warriorjs-abilities/src/walk.test.js
+++ b/packages/warriorjs-abilities/src/walk.test.js
@@ -9,7 +9,7 @@ describe('walk', () => {
   beforeEach(() => {
     unit = {
       move: jest.fn(),
-      say: jest.fn(),
+      log: jest.fn(),
     };
     walk = walkCreator()(unit);
   });
@@ -43,15 +43,15 @@ describe('walk', () => {
         toString: () => 'space',
       });
       walk.perform();
-      expect(unit.say).toHaveBeenCalledWith(`walks ${FORWARD}`);
-      expect(unit.say).toHaveBeenLastCalledWith('bumps into space');
+      expect(unit.log).toHaveBeenCalledWith(`walks ${FORWARD}`);
+      expect(unit.log).toHaveBeenLastCalledWith('bumps into space');
       expect(unit.move).not.toHaveBeenCalled();
     });
 
     test('moves in specified direction if space if empty', () => {
       unit.getSpaceAt = () => ({ isEmpty: () => true });
       walk.perform(RIGHT);
-      expect(unit.say).toHaveBeenCalledWith(`walks ${RIGHT}`);
+      expect(unit.log).toHaveBeenCalledWith(`walks ${RIGHT}`);
       expect(unit.move).toHaveBeenCalledWith(RIGHT);
     });
   });

--- a/packages/warriorjs-core/src/Level.test.js
+++ b/packages/warriorjs-core/src/Level.test.js
@@ -12,7 +12,7 @@ describe('Level', () => {
 
   beforeEach(() => {
     warrior = new Warrior();
-    warrior.say = jest.fn();
+    warrior.log = jest.fn();
     floor = new Floor(2, 1, [1, 0]);
     floor.addUnit(warrior, { x: 0, y: 0, facing: EAST });
     floor.warrior = warrior;

--- a/packages/warriorjs-core/src/Unit.js
+++ b/packages/warriorjs-core/src/Unit.js
@@ -151,7 +151,7 @@ class Unit {
         : amount;
     this.health += revisedAmount;
 
-    this.say(`receives ${amount} health, up to ${this.health} health`);
+    this.log(`receives ${amount} health, up to ${this.health} health`);
   }
 
   /**
@@ -167,10 +167,10 @@ class Unit {
     const revisedAmount = this.health - amount < 0 ? this.health : amount;
     this.health -= revisedAmount;
 
-    this.say(`takes ${amount} damage, ${this.health} health power left`);
+    this.log(`takes ${amount} damage, ${this.health} health power left`);
 
     if (!this.health) {
-      this.say('dies');
+      this.log('dies');
       this.vanish();
     }
   }
@@ -255,7 +255,7 @@ class Unit {
    */
   unbind() {
     this.bound = false;
-    this.say('released from bonds');
+    this.log('released from bonds');
   }
 
   /**
@@ -354,7 +354,7 @@ class Unit {
    */
   move(direction, forward = 1, right = 0) {
     this.position.move(direction, [forward, right]);
-    this.say();
+    this.log();
   }
 
   /**
@@ -364,7 +364,7 @@ class Unit {
    */
   rotate(direction) {
     this.position.rotate(direction);
-    this.say();
+    this.log();
   }
 
   /**
@@ -372,7 +372,7 @@ class Unit {
    */
   vanish() {
     this.position = null;
-    this.say();
+    this.log();
   }
 
   /**
@@ -380,7 +380,7 @@ class Unit {
    *
    * @param {string} message The message to log.
    */
-  say(message) {
+  log(message) {
     Logger.unit(this, message);
   }
 

--- a/packages/warriorjs-core/src/Unit.test.js
+++ b/packages/warriorjs-core/src/Unit.test.js
@@ -9,7 +9,7 @@ describe('Unit', () => {
 
   beforeEach(() => {
     unit = new Unit('Joe', '@', 20, 30);
-    unit.say = jest.fn();
+    unit.log = jest.fn();
     floor = new Floor(5, 6, [0, 0]);
     floor.addUnit(unit, { x: 1, y: 2, facing: NORTH });
   });
@@ -188,7 +188,7 @@ describe('Unit', () => {
       unit.health = 5;
       unit.heal(3);
       expect(unit.health).toBe(8);
-      expect(unit.say).toHaveBeenCalledWith(
+      expect(unit.log).toHaveBeenCalledWith(
         'receives 3 health, up to 8 health',
       );
     });
@@ -197,7 +197,7 @@ describe('Unit', () => {
       unit.health = 19;
       unit.heal(2);
       expect(unit.health).toBe(20);
-      expect(unit.say).toHaveBeenCalledWith(
+      expect(unit.log).toHaveBeenCalledWith(
         'receives 2 health, up to 20 health',
       );
     });
@@ -205,7 +205,7 @@ describe('Unit', () => {
     test("doesn't add health when at max", () => {
       unit.heal(1);
       expect(unit.health).toBe(20);
-      expect(unit.say).toHaveBeenCalledWith(
+      expect(unit.log).toHaveBeenCalledWith(
         'receives 1 health, up to 20 health',
       );
     });
@@ -215,7 +215,7 @@ describe('Unit', () => {
     test('subtracts health', () => {
       unit.takeDamage(3);
       expect(unit.health).toBe(17);
-      expect(unit.say).toHaveBeenCalledWith(
+      expect(unit.log).toHaveBeenCalledWith(
         'takes 3 damage, 17 health power left',
       );
     });
@@ -223,7 +223,7 @@ describe('Unit', () => {
     test("doesn't go under zero health", () => {
       unit.takeDamage(21);
       expect(unit.health).toBe(0);
-      expect(unit.say).toHaveBeenCalledWith(
+      expect(unit.log).toHaveBeenCalledWith(
         'takes 21 damage, 0 health power left',
       );
     });
@@ -231,10 +231,10 @@ describe('Unit', () => {
     test('dies when running out of health', () => {
       unit.takeDamage(20);
       expect(unit.isAlive()).toBe(false);
-      expect(unit.say).toHaveBeenCalledWith(
+      expect(unit.log).toHaveBeenCalledWith(
         'takes 20 damage, 0 health power left',
       );
-      expect(unit.say).toHaveBeenCalledWith('dies');
+      expect(unit.log).toHaveBeenCalledWith('dies');
     });
   });
 
@@ -256,7 +256,7 @@ describe('Unit', () => {
     const receiver = new Unit();
     receiver.health = 10;
     receiver.position = {};
-    receiver.say = jest.fn();
+    receiver.log = jest.fn();
     unit.damage(receiver, 3);
     expect(receiver.health).toBe(7);
   });
@@ -270,7 +270,7 @@ describe('Unit', () => {
       receiver.reward = 10;
       receiver.health = 5;
       receiver.position = {};
-      receiver.say = jest.fn();
+      receiver.log = jest.fn();
     });
 
     test('earns points equal to reward when killing unit', () => {
@@ -418,7 +418,7 @@ describe('Unit', () => {
 
     test('murmurs something', () => {
       unit.move(FORWARD);
-      expect(unit.say).toHaveBeenCalled();
+      expect(unit.log).toHaveBeenCalled();
     });
   });
 
@@ -434,7 +434,7 @@ describe('Unit', () => {
 
     test('murmurs something', () => {
       unit.rotate(BACKWARD);
-      expect(unit.say).toHaveBeenCalled();
+      expect(unit.log).toHaveBeenCalled();
     });
   });
 
@@ -447,7 +447,7 @@ describe('Unit', () => {
 
     test('murmurs something', () => {
       unit.vanish();
-      expect(unit.say).toHaveBeenCalled();
+      expect(unit.log).toHaveBeenCalled();
     });
   });
 
@@ -497,7 +497,7 @@ describe('Unit', () => {
         'move',
         'rotate',
         'vanish',
-        'say',
+        'log',
         'toPlayerObject',
       ];
       forbiddenApi.forEach(propertyName => {

--- a/packages/warriorjs-core/src/Warrior.js
+++ b/packages/warriorjs-core/src/Warrior.js
@@ -30,18 +30,18 @@ class Warrior extends Unit {
   performTurn() {
     super.performTurn();
     if (!this.turn.action || this.isBound()) {
-      this.say('does nothing');
+      this.log('does nothing');
     }
   }
 
   earnPoints(points) {
     super.earnPoints(points);
-    this.say(`earns ${points} points`);
+    this.log(`earns ${points} points`);
   }
 
   losePoints(points) {
     super.losePoints(points);
-    this.say(`loses ${points} points`);
+    this.log(`loses ${points} points`);
   }
 
   toJSON() {

--- a/packages/warriorjs-core/src/Warrior.test.js
+++ b/packages/warriorjs-core/src/Warrior.test.js
@@ -6,7 +6,7 @@ describe('Warrior', () => {
 
   beforeEach(() => {
     warrior = new Warrior('Joe', '@', 20);
-    warrior.say = jest.fn();
+    warrior.log = jest.fn();
   });
 
   test('delegates playTurn to the player', () => {
@@ -31,23 +31,23 @@ describe('Warrior', () => {
   test('is upset for not doing anything when no action', () => {
     warrior.turn = { action: null };
     warrior.performTurn();
-    expect(warrior.say).toHaveBeenCalledWith('does nothing');
+    expect(warrior.log).toHaveBeenCalledWith('does nothing');
   });
 
   test('is upset for not doing anything when bound', () => {
     warrior.bind();
     warrior.turn = { action: ['walk', []] };
     warrior.performTurn();
-    expect(warrior.say).toHaveBeenCalledWith('does nothing');
+    expect(warrior.log).toHaveBeenCalledWith('does nothing');
   });
 
   test('is proud of earning points', () => {
     warrior.earnPoints(5);
-    expect(warrior.say).toHaveBeenCalledWith('earns 5 points');
+    expect(warrior.log).toHaveBeenCalledWith('earns 5 points');
   });
 
   test('is upset for losing points', () => {
     warrior.losePoints(5);
-    expect(warrior.say).toHaveBeenCalledWith('loses 5 points');
+    expect(warrior.log).toHaveBeenCalledWith('loses 5 points');
   });
 });

--- a/packages/warriorjs-core/src/getLevel.test.js
+++ b/packages/warriorjs-core/src/getLevel.test.js
@@ -36,12 +36,12 @@ const levelConfig = {
           action: true,
           description: `Move one space in the given direction (${FORWARD} by default).`,
           perform(direction = FORWARD) {
-            unit.say(`walks ${direction}`);
+            unit.log(`walks ${direction}`);
             const space = unit.getSpaceAt(direction);
             if (space.isEmpty()) {
               unit.move(direction);
             } else {
-              unit.say(`bumps into ${space}`);
+              unit.log(`bumps into ${space}`);
             }
           },
         }),
@@ -51,12 +51,12 @@ const levelConfig = {
           perform(direction = FORWARD) {
             const receiver = unit.getSpaceAt(direction).getUnit();
             if (receiver) {
-              unit.say(`attacks ${direction} and hits ${receiver}`);
+              unit.log(`attacks ${direction} and hits ${receiver}`);
               const attackingBackward = direction === BACKWARD;
               const amount = attackingBackward ? 3 : 5;
               unit.damage(receiver, amount);
             } else {
-              unit.say(`attacks ${direction} and hits nothing`);
+              unit.log(`attacks ${direction} and hits nothing`);
             }
           },
         }),
@@ -85,12 +85,12 @@ const levelConfig = {
             perform(direction = FORWARD) {
               const receiver = unit.getSpaceAt(direction).getUnit();
               if (receiver) {
-                unit.say(`attacks ${direction} and hits ${receiver}`);
+                unit.log(`attacks ${direction} and hits ${receiver}`);
                 const attackingBackward = direction === BACKWARD;
                 const amount = attackingBackward ? 2 : 3;
                 unit.damage(receiver, amount);
               } else {
-                unit.say(`attacks ${direction} and hits nothing`);
+                unit.log(`attacks ${direction} and hits nothing`);
               }
             },
           }),

--- a/packages/warriorjs-core/src/runLevel.test.js
+++ b/packages/warriorjs-core/src/runLevel.test.js
@@ -27,12 +27,12 @@ const levelConfig = {
         walk: unit => ({
           action: true,
           perform(direction = FORWARD) {
-            unit.say(`walks ${direction}`);
+            unit.log(`walks ${direction}`);
             const space = unit.getSpaceAt(direction);
             if (space.isEmpty()) {
               unit.move(direction);
             } else {
-              unit.say(`bumps into ${space}`);
+              unit.log(`bumps into ${space}`);
             }
           },
         }),
@@ -41,12 +41,12 @@ const levelConfig = {
           perform(direction = FORWARD) {
             const receiver = unit.getSpaceAt(direction).getUnit();
             if (receiver) {
-              unit.say(`attacks ${direction} and hits ${receiver}`);
+              unit.log(`attacks ${direction} and hits ${receiver}`);
               const attackingBackward = direction === BACKWARD;
               const amount = attackingBackward ? 3 : 5;
               unit.damage(receiver, amount);
             } else {
-              unit.say(`attacks ${direction} and hits nothing`);
+              unit.log(`attacks ${direction} and hits nothing`);
             }
           },
         }),
@@ -73,12 +73,12 @@ const levelConfig = {
             perform(direction = FORWARD) {
               const receiver = unit.getSpaceAt(direction).getUnit();
               if (receiver) {
-                unit.say(`attacks ${direction} and hits ${receiver}`);
+                unit.log(`attacks ${direction} and hits ${receiver}`);
                 const attackingBackward = direction === BACKWARD;
                 const amount = attackingBackward ? 2 : 3;
                 unit.damage(receiver, amount);
               } else {
-                unit.say(`attacks ${direction} and hits nothing`);
+                unit.log(`attacks ${direction} and hits nothing`);
               }
             },
           }),

--- a/packages/warriorjs-effects/src/ticking.js
+++ b/packages/warriorjs-effects/src/ticking.js
@@ -7,14 +7,14 @@ function ticking({ time }) {
         this.time -= 1;
       }
 
-      unit.say('is ticking');
+      unit.log('is ticking');
 
       if (!this.time) {
         this.trigger();
       }
     },
     trigger() {
-      unit.say('explodes, collapsing the ceiling and killing every unit');
+      unit.log('explodes, collapsing the ceiling and killing every unit');
       [...unit.getOtherUnits(), unit].forEach(anotherUnit =>
         anotherUnit.takeDamage(anotherUnit.health),
       );

--- a/packages/warriorjs-effects/src/ticking.test.js
+++ b/packages/warriorjs-effects/src/ticking.test.js
@@ -8,7 +8,7 @@ describe('ticking', () => {
     unit = {
       health: 20,
       takeDamage: jest.fn(),
-      say: jest.fn(),
+      log: jest.fn(),
     };
     ticking = tickingCreator({ time: 3 })(unit);
   });
@@ -23,7 +23,7 @@ describe('ticking', () => {
     test('counts down bomb timer once', () => {
       ticking.passTurn();
       expect(ticking.time).toBe(2);
-      expect(unit.say).toHaveBeenCalledWith('is ticking');
+      expect(unit.log).toHaveBeenCalledWith('is ticking');
     });
 
     test("doesn't count down bomb timer below zero", () => {
@@ -51,7 +51,7 @@ describe('ticking', () => {
       };
       unit.getOtherUnits = () => [anotherUnit];
       ticking.trigger();
-      expect(unit.say).toHaveBeenCalledWith(
+      expect(unit.log).toHaveBeenCalledWith(
         'explodes, collapsing the ceiling and killing every unit',
       );
       expect(anotherUnit.takeDamage).toHaveBeenCalledWith(10);


### PR DESCRIPTION
Rename `unit.say()` to the more appropriate `unit.log()`.