### PR TITLE
Add unit.release() method

### DIFF
--- a/packages/warriorjs-abilities/src/rescue.js
+++ b/packages/warriorjs-abilities/src/rescue.js
@@ -10,11 +10,7 @@ function rescue() {
       const receiver = unit.getSpaceAt(direction).getUnit();
       if (receiver && receiver.isBound()) {
         unit.log(`unbinds ${direction} and rescues ${receiver}`);
-        receiver.unbind();
-        if (receiver.isFriendly()) {
-          receiver.vanish();
-          unit.earnPoints(receiver.reward);
-        }
+        unit.release(receiver);
       } else {
         unit.log(`unbinds ${direction} and rescues nothing`);
       }

--- a/packages/warriorjs-abilities/src/rescue.test.js
+++ b/packages/warriorjs-abilities/src/rescue.test.js
@@ -8,7 +8,7 @@ describe('rescue', () => {
 
   beforeEach(() => {
     unit = {
-      earnPoints: jest.fn(),
+      release: jest.fn(),
       log: jest.fn(),
     };
     rescue = rescueCreator()(unit);
@@ -50,11 +50,7 @@ describe('rescue', () => {
 
       beforeEach(() => {
         receiver = {
-          reward: 20,
-          isFriendly: () => false,
           isBound: () => true,
-          unbind: jest.fn(),
-          vanish: jest.fn(),
           toString: () => 'receiver',
         };
         unit.getSpaceAt = () => ({ getUnit: () => receiver });
@@ -66,21 +62,15 @@ describe('rescue', () => {
         expect(unit.log).toHaveBeenCalledWith(
           `unbinds ${FORWARD} and rescues nothing`,
         );
+        expect(unit.release).not.toHaveBeenCalled();
       });
 
-      test('rescues receiver', () => {
+      test('releases receiver', () => {
         rescue.perform();
         expect(unit.log).toHaveBeenCalledWith(
           `unbinds ${FORWARD} and rescues receiver`,
         );
-        expect(receiver.unbind).toHaveBeenCalled();
-      });
-
-      test('earns points if rescuing a friendly unit', () => {
-        receiver.isFriendly = () => true;
-        rescue.perform();
-        expect(receiver.vanish).toHaveBeenCalled();
-        expect(unit.earnPoints).toHaveBeenCalledWith(20);
+        expect(unit.release).toHaveBeenCalledWith(receiver);
       });
     });
   });

--- a/packages/warriorjs-core/src/Unit.js
+++ b/packages/warriorjs-core/src/Unit.js
@@ -242,12 +242,16 @@ class Unit {
   }
 
   /**
-   * Checks if the unit is bound.
+   * Unbinds another unit.
    *
-   * @returns {boolean} Whether the unit is bound or not.
+   * @param {Unit} receiver The unit to unbind.
    */
-  isBound() {
-    return this.bound;
+  release(receiver) {
+    receiver.unbind();
+    if (receiver.isFriendly()) {
+      receiver.vanish();
+      this.earnPoints(receiver.reward);
+    }
   }
 
   /**
@@ -263,6 +267,15 @@ class Unit {
    */
   bind() {
     this.bound = true;
+  }
+
+  /**
+   * Checks if the unit is bound.
+   *
+   * @returns {boolean} Whether the unit is bound or not.
+   */
+  isBound() {
+    return this.bound;
   }
 
   /**

--- a/packages/warriorjs-core/src/Unit.test.js
+++ b/packages/warriorjs-core/src/Unit.test.js
@@ -316,6 +316,48 @@ describe('Unit', () => {
     expect(unit.isHostile()).toBe(false);
   });
 
+  describe('when releasing', () => {
+    let receiver;
+
+    beforeEach(() => {
+      receiver = new Unit();
+      receiver.reward = 10;
+      receiver.bound = true;
+      receiver.position = {};
+      receiver.log = jest.fn();
+    });
+
+    test('unbinds the unit', () => {
+      receiver.unbind = jest.fn();
+      unit.release(receiver);
+      expect(receiver.unbind).toHaveBeenCalled();
+    });
+
+    test("doesn't earn points", () => {
+      unit.earnPoints = jest.fn();
+      unit.release(receiver);
+      expect(unit.earnPoints).not.toHaveBeenCalled();
+    });
+
+    describe('friendly unit', () => {
+      beforeEach(() => {
+        receiver.hostile = false;
+      });
+
+      test('vanishes the unit', () => {
+        receiver.vanish = jest.fn();
+        unit.release(receiver);
+        expect(receiver.vanish).toHaveBeenCalled();
+      });
+
+      test('earns points equal to reward', () => {
+        unit.earnPoints = jest.fn();
+        unit.release(receiver);
+        expect(unit.earnPoints).toHaveBeenCalledWith(10);
+      });
+    });
+  });
+
   test('is bound after calling bind', () => {
     unit.bind();
     expect(unit.isBound()).toBe(true);


### PR DESCRIPTION
Move release logic (unbinding and scoring) from the rescue ability to the core.