### PR TITLE
Print level before play (independently)

### DIFF
--- a/packages/warriorjs-cli/package.json
+++ b/packages/warriorjs-cli/package.json
@@ -59,6 +59,7 @@
     "make-dir": "^1.3.0",
     "path-type": "^3.0.0",
     "strip-ansi": "^4.0.0",
+    "wrap-ansi": "^3.0.1",
     "yargs": "^11.0.0"
   }
 }

--- a/packages/warriorjs-cli/src/Game.js
+++ b/packages/warriorjs-cli/src/Game.js
@@ -15,6 +15,7 @@ import printLevelReport from './ui/printLevelReport';
 import printLevel from './ui/printLevel';
 import printLine from './ui/printLine';
 import printPlay from './ui/printPlay';
+import printSeparator from './ui/printSeparator';
 import printSuccessLine from './ui/printSuccessLine';
 import printTowerReport from './ui/printTowerReport';
 import printWarningLine from './ui/printWarningLine';
@@ -305,6 +306,8 @@ class Game {
     if (!this.silencePlay) {
       await printPlay(levelNumber, events, this.delay);
     }
+
+    printSeparator();
 
     if (!passed) {
       printFailureLine(

--- a/packages/warriorjs-cli/src/Game.js
+++ b/packages/warriorjs-cli/src/Game.js
@@ -12,6 +12,7 @@ import Tower from './Tower';
 import getLevelConfig from './utils/getLevelConfig';
 import printFailureLine from './ui/printFailureLine';
 import printLevelReport from './ui/printLevelReport';
+import printLevel from './ui/printLevel';
 import printLine from './ui/printLine';
 import printPlay from './ui/printPlay';
 import printSuccessLine from './ui/printSuccessLine';
@@ -295,6 +296,9 @@ class Game {
    */
   async playLevel(levelNumber) {
     const levelConfig = getLevelConfig(levelNumber, this.tower, this.profile);
+
+    const level = getLevel(levelConfig);
+    printLevel(level);
 
     const { events, passed, score } = await this.runLevel(levelConfig);
 

--- a/packages/warriorjs-cli/src/ui/printFloorMap.js
+++ b/packages/warriorjs-cli/src/ui/printFloorMap.js
@@ -4,7 +4,7 @@ import printLine from './printLine';
 /**
  * Prints the floor map.
  *
- * @param {Object} floor The map of the floor.
+ * @param {Object} map The map of the floor.
  */
 function printFloorMap(map) {
   const floorMap = map

--- a/packages/warriorjs-cli/src/ui/printLevel.js
+++ b/packages/warriorjs-cli/src/ui/printLevel.js
@@ -1,0 +1,19 @@
+import printFloorMap from './printFloorMap';
+import printLevelDescription from './printLevelDescription';
+import printLevelHeader from './printLevelHeader';
+
+/**
+ * Prints the level.
+ *
+ * @param {Object} level The level to print.
+ * @param {number} level.number The number of the level.
+ * @param {string} level.description The description of the level.
+ * @param {Object} level.floor.map The map of the floor.
+ */
+function printLevel({ number, description, floor: { map } }) {
+  printLevelHeader(number);
+  printLevelDescription(description);
+  printFloorMap(map);
+}
+
+export default printLevel;

--- a/packages/warriorjs-cli/src/ui/printLevel.test.js
+++ b/packages/warriorjs-cli/src/ui/printLevel.test.js
@@ -1,0 +1,20 @@
+import printFloorMap from './printFloorMap';
+import printLevel from './printLevel';
+import printLevelDescription from './printLevelDescription';
+import printLevelHeader from './printLevelHeader';
+
+jest.mock('./printFloorMap');
+jest.mock('./printLevelDescription');
+jest.mock('./printLevelHeader');
+
+test('prints level header, description, and floor map', () => {
+  const level = {
+    number: 1,
+    description: 'foo',
+    floor: { map: 'map' },
+  };
+  printLevel(level);
+  expect(printLevelHeader).toHaveBeenCalledWith(1);
+  expect(printLevelDescription).toHaveBeenCalledWith('foo');
+  expect(printFloorMap).toHaveBeenCalledWith('map');
+});

--- a/packages/warriorjs-cli/src/ui/printLevelDescription.js
+++ b/packages/warriorjs-cli/src/ui/printLevelDescription.js
@@ -1,0 +1,12 @@
+import chalk from 'chalk';
+import wrapAnsi from 'wrap-ansi';
+
+import getScreenSize from './getScreenSize';
+import printLine from './printLine';
+
+function printLevelDescription(description) {
+  const [screenWidth] = getScreenSize();
+  printLine(wrapAnsi(chalk.italic(description), screenWidth, { hard: true }));
+}
+
+export default printLevelDescription;

--- a/packages/warriorjs-cli/src/ui/printLevelDescription.test.js
+++ b/packages/warriorjs-cli/src/ui/printLevelDescription.test.js
@@ -1,0 +1,26 @@
+import style from 'ansi-styles';
+
+import getScreenSize from './getScreenSize';
+import printLevelDescription from './printLevelDescription';
+import printLine from './printLine';
+
+jest.mock('./getScreenSize');
+jest.mock('./printLine');
+
+test('prints level description in italics', () => {
+  getScreenSize.mockReturnValue([11, 0]);
+  printLevelDescription('foo');
+  expect(printLine).toHaveBeenCalledWith(
+    `${style.italic.open}foo${style.italic.close}`,
+  );
+});
+
+test("wraps description if it's wider than screen", () => {
+  getScreenSize.mockReturnValue([11, 0]);
+  printLevelDescription('foo foo foo foo');
+  expect(printLine).toHaveBeenCalledWith(
+    `${style.italic.open}foo foo foo${style.italic.close}\n${
+      style.italic.open
+    }foo${style.italic.close}`,
+  );
+});

--- a/packages/warriorjs-cli/src/ui/printLevelHeader.js
+++ b/packages/warriorjs-cli/src/ui/printLevelHeader.js
@@ -8,7 +8,10 @@ import printRow from './printRow';
  * @param {number} levelNumber The level number.
  */
 function printLevelHeader(levelNumber) {
-  printRow(` level ${levelNumber} `, 'center', chalk.gray('#'));
+  printRow(` level ${levelNumber} `, {
+    position: 'middle',
+    padding: chalk.gray('#'),
+  });
 }
 
 export default printLevelHeader;

--- a/packages/warriorjs-cli/src/ui/printLevelHeader.test.js
+++ b/packages/warriorjs-cli/src/ui/printLevelHeader.test.js
@@ -7,9 +7,8 @@ jest.mock('./printRow');
 
 test('prints level header', () => {
   printLevelHeader(1);
-  expect(printRow).toHaveBeenCalledWith(
-    ' level 1 ',
-    'center',
-    `${style.gray.open}#${style.gray.close}`,
-  );
+  expect(printRow).toHaveBeenCalledWith(' level 1 ', {
+    position: 'middle',
+    padding: `${style.gray.open}#${style.gray.close}`,
+  });
 });

--- a/packages/warriorjs-cli/src/ui/printPlay.js
+++ b/packages/warriorjs-cli/src/ui/printPlay.js
@@ -1,7 +1,6 @@
 import sleep from 'delay';
 
 import printBoard from './printBoard';
-import printLevelHeader from './printLevelHeader';
 import printTurnHeader from './printTurnHeader';
 import printLogMessage from './printLogMessage';
 
@@ -16,12 +15,6 @@ async function printPlay(levelNumber, events, delay) {
   let boardOffset = 0;
   // eslint-disable-next-line no-restricted-syntax
   for (const event of events) {
-    if (turnNumber === 0) {
-      printLevelHeader(levelNumber);
-      printBoard(event.floor, boardOffset);
-      await sleep(delay); // eslint-disable-line no-await-in-loop
-    }
-
     const { type } = event;
     switch (type) {
       case 'TURN':

--- a/packages/warriorjs-cli/src/ui/printPlay.test.js
+++ b/packages/warriorjs-cli/src/ui/printPlay.test.js
@@ -1,7 +1,6 @@
 import delay from 'delay';
 
 import printBoard from './printBoard';
-import printLevelHeader from './printLevelHeader';
 import printLogMessage from './printLogMessage';
 import printPlay from './printPlay';
 import printTurnHeader from './printTurnHeader';
@@ -28,21 +27,9 @@ test('starts counting board offset from zero, increments on each UNIT event with
   ];
   await printPlay(1, events);
   expect(printBoard.mock.calls[0][1]).toBe(0);
-  expect(printBoard.mock.calls[1][1]).toBe(0);
+  expect(printBoard.mock.calls[1][1]).toBe(1);
   expect(printBoard.mock.calls[2][1]).toBe(1);
-  expect(printBoard.mock.calls[3][1]).toBe(1);
-  expect(printBoard.mock.calls[4][1]).toBe(0);
-});
-
-test('prints level header and board on first event', async () => {
-  const events = [
-    { type: 'TURN', floor: 'floor1' },
-    { type: 'UNIT', floor: 'floor2' },
-  ];
-  await printPlay(1, events);
-  expect(printLevelHeader).toHaveBeenCalledTimes(1);
-  expect(printLevelHeader).toHaveBeenCalledWith(1);
-  expect(printBoard).toHaveBeenCalledTimes(3);
+  expect(printBoard.mock.calls[3][1]).toBe(0);
 });
 
 test('prints turn header on each TURN event', async () => {
@@ -72,7 +59,7 @@ test('ignores events of unknown type', async () => {
   await printPlay(1, events);
 });
 
-test('sleeps the specified time once at the beginning and after each event', async () => {
+test('sleeps the specified time after each event', async () => {
   const events = [
     { type: 'TURN' },
     { type: 'UNIT' },
@@ -80,6 +67,6 @@ test('sleeps the specified time once at the beginning and after each event', asy
     { type: 'UNIT' },
   ];
   await printPlay(1, events, 42);
-  expect(delay).toHaveBeenCalledTimes(5);
+  expect(delay).toHaveBeenCalledTimes(4);
   expect(delay).toHaveBeenCalledWith(42);
 });

--- a/packages/warriorjs-cli/src/ui/printRow.js
+++ b/packages/warriorjs-cli/src/ui/printRow.js
@@ -5,23 +5,24 @@ import printLine from './printLine';
  * Prints a message and fills the rest of the line with a padding character.
  *
  * @param {string} message The message to print.
- * @param {string} align The message alignment.
- * @param {string} paddingCharacter The padding character.
+ * @param {Object} options The options.
+ * @param {string} options.position The position of the message.
+ * @param {string} options.padding The padding character.
  */
-function printRow(message, align = 'left', paddingCharacter = ' ') {
+function printRow(message, { position = 'start', padding = ' ' } = {}) {
   const [screenWidth] = getScreenSize();
   const rowLength = screenWidth - 1; // Consider line break length.
-  const startPadding = paddingCharacter.repeat(
+  const startPadding = padding.repeat(
     Math.floor((rowLength - message.length) / 2),
   );
-  const endPadding = paddingCharacter.repeat(
+  const endPadding = padding.repeat(
     Math.ceil((rowLength - message.length) / 2),
   );
-  if (align === 'left') {
+  if (position === 'start') {
     printLine(`${message}${startPadding}${endPadding}`);
-  } else if (align === 'center') {
+  } else if (position === 'middle') {
     printLine(`${startPadding}${message}${endPadding}`);
-  } else if (align === 'right') {
+  } else if (position === 'end') {
     printLine(`${startPadding}${endPadding}${message}`);
   }
 }

--- a/packages/warriorjs-cli/src/ui/printRow.test.js
+++ b/packages/warriorjs-cli/src/ui/printRow.test.js
@@ -7,36 +7,36 @@ jest.mock('./printLine');
 
 test('prints message and fills with padding', () => {
   getScreenSize.mockReturnValue([11, 0]);
-  printRow('foo', 'left', ' ');
+  printRow('foo', { position: 'start', padding: ' ' });
   expect(printLine).toHaveBeenCalledWith('foo       ');
 });
 
-test('aligns left by default', () => {
+test('positions message at the start by default', () => {
   getScreenSize.mockReturnValue([11, 0]);
   printRow('foo');
   expect(printLine).toHaveBeenCalledWith('foo       ');
 });
 
-test('aligns center if specified', () => {
+test('positions message in the middle if specified', () => {
   getScreenSize.mockReturnValue([11, 0]);
-  printRow('foo', 'center');
+  printRow('foo', { position: 'middle' });
   expect(printLine).toHaveBeenCalledWith('   foo    ');
 });
 
-test('aligns right if specified', () => {
+test('positions message at the end if specified', () => {
   getScreenSize.mockReturnValue([11, 0]);
-  printRow('foo', 'right');
+  printRow('foo', { position: 'end' });
   expect(printLine).toHaveBeenCalledWith('       foo');
 });
 
 test('uses whitespace as padding character by default', () => {
   getScreenSize.mockReturnValue([11, 0]);
-  printRow('foo', 'left');
+  printRow('foo');
   expect(printLine).toHaveBeenCalledWith('foo       ');
 });
 
 test('allows to specify padding character', () => {
   getScreenSize.mockReturnValue([11, 0]);
-  printRow('foo', 'left', '-');
+  printRow('foo', { padding: '-' });
   expect(printLine).toHaveBeenCalledWith('foo-------');
 });

--- a/packages/warriorjs-cli/src/ui/printSeparator.js
+++ b/packages/warriorjs-cli/src/ui/printSeparator.js
@@ -1,0 +1,11 @@
+import chalk from 'chalk';
+
+import printRow from './printRow';
+
+function printSeparator() {
+  printRow('', {
+    padding: chalk.gray('-'),
+  });
+}
+
+export default printSeparator;

--- a/packages/warriorjs-cli/src/ui/printSeparator.test.js
+++ b/packages/warriorjs-cli/src/ui/printSeparator.test.js
@@ -1,0 +1,13 @@
+import style from 'ansi-styles';
+
+import printRow from './printRow';
+import printSeparator from './printSeparator';
+
+jest.mock('./printRow');
+
+test('prints row of gray dashes', () => {
+  printSeparator();
+  expect(printRow).toHaveBeenCalledWith('', {
+    padding: `${style.gray.open}-${style.gray.close}`,
+  });
+});

--- a/packages/warriorjs-cli/src/ui/printTurnHeader.js
+++ b/packages/warriorjs-cli/src/ui/printTurnHeader.js
@@ -8,11 +8,10 @@ import printRow from './printRow';
  * @param {number} turnNumber The turn number.
  */
 function printTurnHeader(turnNumber) {
-  printRow(
-    ` turn ${String(turnNumber).padStart(3, '0')} `,
-    'center',
-    chalk.gray('-'),
-  );
+  printRow(` turn ${String(turnNumber).padStart(3, '0')} `, {
+    position: 'middle',
+    padding: chalk.gray('-'),
+  });
 }
 
 export default printTurnHeader;

--- a/packages/warriorjs-cli/src/ui/printTurnHeader.test.js
+++ b/packages/warriorjs-cli/src/ui/printTurnHeader.test.js
@@ -7,9 +7,8 @@ jest.mock('./printRow');
 
 test('prints turn header', () => {
   printTurnHeader(1);
-  expect(printRow).toHaveBeenCalledWith(
-    ' turn 001 ',
-    'center',
-    `${style.gray.open}-${style.gray.close}`,
-  );
+  expect(printRow).toHaveBeenCalledWith(' turn 001 ', {
+    position: 'middle',
+    padding: `${style.gray.open}-${style.gray.close}`,
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -6627,6 +6627,13 @@ wrap-ansi@^2.0.0:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
 
+wrap-ansi@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-3.0.1.tgz#288a04d87eda5c286e060dfe8f135ce8d007f8ba"
+  dependencies:
+    string-width "^2.1.1"
+    strip-ansi "^4.0.0"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"


### PR DESCRIPTION
**Before:**

![screen shot 2018-05-21 at 01 35 35](https://user-images.githubusercontent.com/5600126/40290841-5476e9fe-5c97-11e8-95ec-bc3251e393e1.png)
![screen shot 2018-05-21 at 01 35 43](https://user-images.githubusercontent.com/5600126/40290844-5937da20-5c97-11e8-9f07-b279216e8527.png)

With `--silent`:

![untitled](https://user-images.githubusercontent.com/5600126/40290913-d2ea5b90-5c97-11e8-8b7e-7466766f52ca.png)

**After:**

![screen shot 2018-05-21 at 01 34 27](https://user-images.githubusercontent.com/5600126/40290925-ec13ae00-5c97-11e8-9afa-572f94c7ac15.png)
![screen shot 2018-05-21 at 01 34 48](https://user-images.githubusercontent.com/5600126/40290926-ef194c5e-5c97-11e8-866f-504d97d55ad9.png)

With `--silent`:

![untitled](https://user-images.githubusercontent.com/5600126/40290975-34df704c-5c98-11e8-9adb-2c14eae17b41.png)