### PR TITLE
Add RGB color to units

### DIFF
--- a/docs/play/cli-tips.md
+++ b/docs/play/cli-tips.md
@@ -9,3 +9,6 @@ title: CLI Tips
 
 - Make sure to try the different options you can pass to the `warriorjs`
   command. Run `warriorjs --help` to see them all.
+
+* If you're on Windows, consider using [cmder](http://cmder.net) instead of
+  `cmd.exe`.

--- a/packages/warriorjs-cli/src/ui/getUnitStyle.js
+++ b/packages/warriorjs-cli/src/ui/getUnitStyle.js
@@ -1,23 +1,18 @@
 import chalk from 'chalk';
 
-const unitStyles = [
-  chalk.cyan,
-  chalk.magenta,
-  chalk.red,
-  chalk.yellow,
-  chalk.green,
-  chalk.blue,
-];
+// Downsample colors from RGB to 256 color ANSI for greater uniformity.
+const ctx = new chalk.constructor({ level: 2 });
 
 /**
  * Returns the style for the given unit.
  *
- * @param {string} unitName The name of the unit to get the style for.
+ * @param {Object} unit The unit to get the style for.
+ * @param {string} unit.color The color of the unit (hex).
  *
  * @returns {Function} The style function.
  */
-function getUnitStyle(unitName) {
-  return unitStyles[unitName.charCodeAt(0) % unitStyles.length];
+function getUnitStyle({ color }) {
+  return ctx.hex(color);
 }
 
 export default getUnitStyle;

--- a/packages/warriorjs-cli/src/ui/getUnitStyle.test.js
+++ b/packages/warriorjs-cli/src/ui/getUnitStyle.test.js
@@ -2,7 +2,10 @@ import style from 'ansi-styles';
 
 import getUnitStyle from './getUnitStyle';
 
-test("returns calculated style function based on unit's name", () => {
-  const unitStyle = getUnitStyle('foo');
-  expect(unitStyle('f')).toEqual(`${style.cyan.open}f${style.cyan.close}`);
+test('downsamples RGB to 256 color ANSI', () => {
+  const color = '#8fbcbb';
+  const unitStyle = getUnitStyle({ color });
+  expect(unitStyle('@')).toBe(
+    `${style.color.ansi256.hex(color)}@${style.color.close}`,
+  );
 });

--- a/packages/warriorjs-cli/src/ui/printFloorMap.js
+++ b/packages/warriorjs-cli/src/ui/printFloorMap.js
@@ -13,8 +13,7 @@ function printFloorMap(floorMap) {
         row
           .map(({ character, unit }) => {
             if (unit) {
-              const style = getUnitStyle(unit.name);
-              return style(character);
+              return getUnitStyle(unit)(character);
             }
 
             return character;

--- a/packages/warriorjs-cli/src/ui/printFloorMap.test.js
+++ b/packages/warriorjs-cli/src/ui/printFloorMap.test.js
@@ -6,14 +6,14 @@ jest.mock('./getUnitStyle');
 jest.mock('./printLine');
 
 test('prints floor map', () => {
-  const style = jest.fn(unit => unit);
-  getUnitStyle.mockImplementation(() => style);
+  const unitStyle = jest.fn(string => string);
+  getUnitStyle.mockReturnValue(unitStyle);
   const map = [
-    [{ character: 'a' }, { character: 'f', unit: { name: 'foo' } }],
-    [{ character: 'b' }, { character: 'c' }],
+    [{ character: 'a' }, { character: 'b', unit: 'unit' }],
+    [{ character: 'c' }, { character: 'd' }],
   ];
   printFloorMap(map);
-  expect(getUnitStyle).toHaveBeenCalledWith('foo');
-  expect(style).toHaveBeenCalledWith('f');
-  expect(printLine).toHaveBeenCalledWith('af\nbc');
+  expect(getUnitStyle).toHaveBeenCalledWith('unit');
+  expect(unitStyle).toHaveBeenCalledWith('b');
+  expect(printLine).toHaveBeenCalledWith('ab\ncd');
 });

--- a/packages/warriorjs-cli/src/ui/printLogMessage.js
+++ b/packages/warriorjs-cli/src/ui/printLogMessage.js
@@ -7,13 +7,11 @@ import printLine from './printLine';
  * Prints a message to the log.
  *
  * @param {Object} unit The unit the message belongs to.
- * @param {string} unit.name The name of the unit.
  * @param {string} message The message to print.
  */
-function printLogMessage({ name }, message) {
+function printLogMessage(unit, message) {
   const prompt = chalk.gray.dim('>');
-  const style = getUnitStyle(name);
-  const logMessage = style(`${name} ${message}`);
+  const logMessage = getUnitStyle(unit)(`${unit.name} ${message}`);
   printLine(`${prompt} ${logMessage}`);
 }
 

--- a/packages/warriorjs-cli/src/ui/printLogMessage.test.js
+++ b/packages/warriorjs-cli/src/ui/printLogMessage.test.js
@@ -8,11 +8,14 @@ jest.mock('./getUnitStyle');
 jest.mock('./printLine');
 
 test('prints log message with dimmed gray prompt', () => {
-  getUnitStyle.mockImplementation(() => unit => unit);
+  const unitStyle = jest.fn(string => string);
+  getUnitStyle.mockReturnValue(unitStyle);
   const unit = { name: 'Joe' };
   const prompt = `${style.gray.open}${style.dim.open}>${style.dim.close}${
     style.gray.close
   }`;
   printLogMessage(unit, 'is awesome!');
+  expect(getUnitStyle).toHaveBeenCalledWith(unit);
+  expect(unitStyle).toHaveBeenCalledWith('Joe is awesome!');
   expect(printLine).toHaveBeenCalledWith(`${prompt} Joe is awesome!`);
 });

--- a/packages/warriorjs-core/src/Unit.js
+++ b/packages/warriorjs-core/src/Unit.js
@@ -8,6 +8,7 @@ class Unit {
    *
    * @param {string} name The name of the unit.
    * @param {string} character The character of the unit.
+   * @param {string} color The color of the unit.
    * @param {number} maxHealth The max health in HP.
    * @param {number} reward The number of points to reward when interacting.
    * @param {boolean} enemy Whether the unit is an enemy or not.
@@ -16,6 +17,7 @@ class Unit {
   constructor(
     name,
     character,
+    color,
     maxHealth,
     reward = null,
     enemy = true,
@@ -23,6 +25,7 @@ class Unit {
   ) {
     this.name = name;
     this.character = character;
+    this.color = color;
     this.maxHealth = maxHealth;
     this.reward = reward === null ? maxHealth : reward;
     this.enemy = enemy;
@@ -407,6 +410,7 @@ class Unit {
   toJSON() {
     return {
       name: this.name,
+      color: this.color,
       maxHealth: this.maxHealth,
     };
   }

--- a/packages/warriorjs-core/src/Unit.test.js
+++ b/packages/warriorjs-core/src/Unit.test.js
@@ -15,7 +15,7 @@ describe('Unit', () => {
   let floor;
 
   beforeEach(() => {
-    unit = new Unit('Joe', '@', 20);
+    unit = new Unit('Joe', '@', '#8fbcbb', 20);
     unit.log = jest.fn();
     floor = new Floor(5, 6, [0, 0]);
     floor.addUnit(unit, { x: 1, y: 2, facing: NORTH });
@@ -29,6 +29,10 @@ describe('Unit', () => {
     expect(unit.character).toBe('@');
   });
 
+  test('has a color', () => {
+    expect(unit.color).toBe('#8fbcbb');
+  });
+
   test('has a max health', () => {
     expect(unit.maxHealth).toBe(20);
   });
@@ -38,7 +42,7 @@ describe('Unit', () => {
   });
 
   test('allows to specify reward', () => {
-    expect(new Unit('Foo', 'f', 20, 30).reward).toBe(30);
+    expect(new Unit('Foo', 'f', '#fff', 20, 30).reward).toBe(30);
   });
 
   test('has an enemy status which defaults to true', () => {
@@ -46,7 +50,7 @@ describe('Unit', () => {
   });
 
   test('allows to specify enemy status', () => {
-    expect(new Unit('Foo', 'f', 20, 30, false).enemy).toBe(false);
+    expect(new Unit('Foo', 'f', '#fff', 20, 30, false).enemy).toBe(false);
   });
 
   test('has a bound status which defaults to false', () => {
@@ -54,11 +58,11 @@ describe('Unit', () => {
   });
 
   test('has a position which is null before adding the unit to the floor', () => {
-    expect(new Unit('Foo', 'f', 20).position).toBeNull();
+    expect(new Unit('Foo', 'f', '#fff', 20).position).toBeNull();
   });
 
   test('allows to specify bound status', () => {
-    expect(new Unit('Foo', 'f', 20, 30, false, true).bound).toBe(true);
+    expect(new Unit('Foo', 'f', '#fff', 20, 30, false, true).bound).toBe(true);
   });
 
   test('has a health which defaults to max health', () => {
@@ -558,6 +562,7 @@ describe('Unit', () => {
   test('has a minimal JSON representation', () => {
     expect(unit.toJSON()).toEqual({
       name: 'Joe',
+      color: '#8fbcbb',
       maxHealth: 20,
     });
   });

--- a/packages/warriorjs-core/src/Warrior.js
+++ b/packages/warriorjs-core/src/Warrior.js
@@ -7,10 +7,11 @@ class Warrior extends Unit {
    *
    * @param {string} name The name of the warrior.
    * @param {string} character The character of the warrior.
+   * @param {string} color The color of the warrior.
    * @param {number} maxHealth The max health in HP.
    */
-  constructor(name, character, maxHealth) {
-    super(name, character, maxHealth, null, false);
+  constructor(name, character, color, maxHealth) {
+    super(name, character, color, maxHealth, null, false);
   }
 
   performTurn() {

--- a/packages/warriorjs-core/src/Warrior.test.js
+++ b/packages/warriorjs-core/src/Warrior.test.js
@@ -4,7 +4,7 @@ describe('Warrior', () => {
   let warrior;
 
   beforeEach(() => {
-    warrior = new Warrior('Joe', '@', 20);
+    warrior = new Warrior('Joe', '@', '#8fbcbb', 20);
     warrior.addAbility('feel', { description: 'a description' });
     warrior.addAbility('walk', { action: true, description: 'a description' });
     warrior.log = jest.fn();

--- a/packages/warriorjs-core/src/getLevel.test.js
+++ b/packages/warriorjs-core/src/getLevel.test.js
@@ -23,6 +23,7 @@ const levelConfig = {
     warrior: {
       name: 'Joe',
       character: '@',
+      color: '#8fbcbb',
       maxHealth: 20,
       abilities: {
         walk: () => ({
@@ -47,6 +48,7 @@ const levelConfig = {
       {
         name: 'Sludge',
         character: 's',
+        color: '#d08770',
         maxHealth: 12,
         abilities: {
           attack: () => ({
@@ -103,6 +105,7 @@ test('returns level', () => {
           character: '@',
           unit: {
             name: 'Joe',
+            color: '#8fbcbb',
             maxHealth: 20,
           },
         },
@@ -113,6 +116,7 @@ test('returns level', () => {
           character: 's',
           unit: {
             name: 'Sludge',
+            color: '#d08770',
             maxHealth: 12,
           },
         },

--- a/packages/warriorjs-core/src/loadLevel.js
+++ b/packages/warriorjs-core/src/loadLevel.js
@@ -38,11 +38,11 @@ function loadEffects(unit, effects = {}) {
  * @param {string} [playerCode] The code of the player.
  */
 function loadWarrior(
-  { name, character, maxHealth, abilities, effects, position },
+  { name, character, color, maxHealth, abilities, effects, position },
   floor,
   playerCode,
 ) {
-  const warrior = new Warrior(name, character, maxHealth);
+  const warrior = new Warrior(name, character, color, maxHealth);
   loadAbilities(warrior, abilities);
   loadEffects(warrior, effects);
   warrior.playTurn = playerCode ? loadPlayer(playerCode) : () => {};
@@ -59,6 +59,7 @@ function loadUnit(
   {
     name,
     character,
+    color,
     maxHealth,
     reward,
     enemy,
@@ -70,7 +71,15 @@ function loadUnit(
   },
   floor,
 ) {
-  const unit = new Unit(name, character, maxHealth, reward, enemy, bound);
+  const unit = new Unit(
+    name,
+    character,
+    color,
+    maxHealth,
+    reward,
+    enemy,
+    bound,
+  );
   loadAbilities(unit, abilities);
   loadEffects(unit, effects);
   unit.playTurn = playTurn;

--- a/packages/warriorjs-units/src/Archer.js
+++ b/packages/warriorjs-units/src/Archer.js
@@ -4,6 +4,7 @@ import { look, shoot } from '@warriorjs/abilities';
 const Archer = {
   name: 'Archer',
   character: 'a',
+  color: '#ebcb8b',
   maxHealth: 7,
   abilities: {
     look: look({ range: 3 }),

--- a/packages/warriorjs-units/src/Archer.test.js
+++ b/packages/warriorjs-units/src/Archer.test.js
@@ -14,6 +14,10 @@ describe('Archer', () => {
     expect(Archer.character).toBe('a');
   });
 
+  test('has #ebcb8b color', () => {
+    expect(Archer.color).toBe('#ebcb8b');
+  });
+
   test('has 7 max health', () => {
     expect(Archer.maxHealth).toBe(7);
   });

--- a/packages/warriorjs-units/src/Captive.js
+++ b/packages/warriorjs-units/src/Captive.js
@@ -1,6 +1,7 @@
 const Captive = {
   name: 'Captive',
   character: 'C',
+  color: '#81a1c1',
   maxHealth: 1,
   reward: 20,
   enemy: false,

--- a/packages/warriorjs-units/src/Captive.test.js
+++ b/packages/warriorjs-units/src/Captive.test.js
@@ -5,6 +5,10 @@ describe('Captive', () => {
     expect(Captive.character).toBe('C');
   });
 
+  test('has #81a1c1 color', () => {
+    expect(Captive.color).toBe('#81a1c1');
+  });
+
   test('has 1 max health', () => {
     expect(Captive.maxHealth).toBe(1);
   });

--- a/packages/warriorjs-units/src/Sludge.js
+++ b/packages/warriorjs-units/src/Sludge.js
@@ -4,6 +4,7 @@ import { attack, feel } from '@warriorjs/abilities';
 const Sludge = {
   name: 'Sludge',
   character: 's',
+  color: '#d08770',
   maxHealth: 12,
   abilities: {
     attack: attack({ power: 3 }),

--- a/packages/warriorjs-units/src/Sludge.test.js
+++ b/packages/warriorjs-units/src/Sludge.test.js
@@ -14,6 +14,10 @@ describe('Sludge', () => {
     expect(Sludge.character).toBe('s');
   });
 
+  test('has #d08770 color', () => {
+    expect(Sludge.color).toBe('#d08770');
+  });
+
   test('has 12 max health', () => {
     expect(Sludge.maxHealth).toBe(12);
   });

--- a/packages/warriorjs-units/src/ThickSludge.js
+++ b/packages/warriorjs-units/src/ThickSludge.js
@@ -4,6 +4,7 @@ const ThickSludge = {
   ...Sludge,
   name: 'Thick Sludge',
   character: 'S',
+  color: '#bf616a',
   maxHealth: 24,
 };
 

--- a/packages/warriorjs-units/src/ThickSludge.test.js
+++ b/packages/warriorjs-units/src/ThickSludge.test.js
@@ -14,6 +14,10 @@ describe('ThickSludge', () => {
     expect(ThickSludge.character).toBe('S');
   });
 
+  test('has #bf616a color', () => {
+    expect(ThickSludge.color).toBe('#bf616a');
+  });
+
   test('has 24 max health', () => {
     expect(ThickSludge.maxHealth).toBe(24);
   });

--- a/packages/warriorjs-units/src/Warrior.js
+++ b/packages/warriorjs-units/src/Warrior.js
@@ -1,5 +1,6 @@
 const Warrior = {
   character: '@',
+  color: '#8fbcbb',
   maxHealth: 20,
 };
 

--- a/packages/warriorjs-units/src/Warrior.test.js
+++ b/packages/warriorjs-units/src/Warrior.test.js
@@ -5,6 +5,10 @@ describe('Warrior', () => {
     expect(Warrior.character).toBe('@');
   });
 
+  test('has #8fbcbb color', () => {
+    expect(Warrior.color).toBe('#8fbcbb');
+  });
+
   test('has 20 max health', () => {
     expect(Warrior.maxHealth).toBe(20);
   });

--- a/packages/warriorjs-units/src/Wizard.js
+++ b/packages/warriorjs-units/src/Wizard.js
@@ -6,6 +6,7 @@ const Wizard = {
   ...Archer,
   name: 'Wizard',
   character: 'w',
+  color: '#b48ead',
   maxHealth: 3,
   abilities: {
     look: look({ range: 3 }),

--- a/packages/warriorjs-units/src/Wizard.test.js
+++ b/packages/warriorjs-units/src/Wizard.test.js
@@ -14,6 +14,10 @@ describe('Wizard', () => {
     expect(Wizard.character).toBe('w');
   });
 
+  test('has #b48ead color', () => {
+    expect(Wizard.color).toBe('#b48ead');
+  });
+
   test('has 3 max health', () => {
     expect(Wizard.maxHealth).toBe(3);
   });


### PR DESCRIPTION
**Before:**

![before](https://user-images.githubusercontent.com/5600126/40587043-6d8658fe-61a0-11e8-92bb-66c3375ad374.png)

_^ Note how the Archer and the Captive had the same color due to the algorithm that was used to select colors for them automatically._

**After:**

![after](https://user-images.githubusercontent.com/5600126/40587046-745f5d38-61a0-11e8-9682-a9461ea88467.png)

(In the CLI, unit colors are downsampled from RGB to 256 color ANSI for greater uniformity.)