### PR TITLE
Load towers dynamically

### DIFF
--- a/docs/towers.md
+++ b/docs/towers.md
@@ -1,0 +1,38 @@
+---
+id: towers
+title: Towers
+---
+
+A **tower** is a WarriorJS world. In addition to defining levels, towers can
+also add new abilities, effects, and units to the game.
+
+The `@warriorjs/cli` package ships with a beginner tower built-in. You'll need
+to install any additional tower you want to play.
+
+## Installing Towers
+
+Towers are automatically loaded if you have them installed in the same
+`node_modules` directory where `@warriorjs/cli` is located. This means that if
+you have installed the game globally, you'll need to install additional towers
+globally. If, on the other hand, you're running the game from a local
+installation, you'll need to install additional towers locally.
+
+Tower package names must start with `@warriorjs/tower-` or `warriorjs-tower-` to
+be registered.
+
+### Official Towers
+
+* [`@warriorjs/tower-beginner`][warriorjs-tower-beginner]
+* [`@warriorjs/tower-intermediate`][warriorjs-tower-intermediate] (beta)
+
+### Community Towers
+
+Have you made a tower? [Add it][add-community-tower] to the list!
+
+## Making Towers
+
+_Coming soon._
+
+[warriorjs-tower-beginner]: /packages/warriorjs-tower-beginner
+[warriorjs-tower-intermediate]: /packages/warriorjs-tower-intermediate
+[add-community-tower]: https://github.com/olistic/warriorjs/edit/master/docs/towers.md

--- a/packages/warriorjs-cli/package.json
+++ b/packages/warriorjs-cli/package.json
@@ -53,10 +53,12 @@
     "chalk": "^2.4.1",
     "delay": "^3.0.0",
     "ejs": "^2.6.1",
+    "find-up": "^2.1.0",
     "globby": "^8.0.1",
     "inquirer": "^5.1.0",
     "inquirer-prompt-suggest": "^0.1.0",
     "lodash.merge": "^4.6.1",
+    "resolve": "^1.7.1",
     "string-width": "^2.1.1",
     "superheroes": "^1.0.0",
     "yargs": "^11.0.0"

--- a/packages/warriorjs-cli/src/Game.js
+++ b/packages/warriorjs-cli/src/Game.js
@@ -7,9 +7,9 @@ import { getLevel, runLevel } from '@warriorjs/core';
 import GameError from './GameError';
 import Profile from './Profile';
 import ProfileGenerator from './ProfileGenerator';
-import Tower from './Tower';
 import getLevelConfig from './utils/getLevelConfig';
 import getWarriorNameSuggestions from './utils/getWarriorNameSuggestions';
+import loadTowers from './loadTowers';
 import printFailureLine from './ui/printFailureLine';
 import printLevelReport from './ui/printLevelReport';
 import printLevel from './ui/printLevel';
@@ -52,8 +52,10 @@ class Game {
     printLine('Welcome to WarriorJS');
 
     try {
+      this.towers = new Map(loadTowers().map(tower => [tower.name, tower]));
+
       this.profile = await this.loadProfile();
-      this.tower = Tower.getTowerByName(this.profile.towerName);
+
       if (this.profile.isEpic()) {
         await this.playEpicMode();
       } else {
@@ -74,20 +76,26 @@ class Game {
   /**
    * Loads a profile into the game.
    *
-   * If there is a .profile file in the run directory, that profile will be
-   * loaded.
-   *
-   * If not, the player will be given the option to choose a profile.
+   * If the game is being run from a profile directory, that profile will be
+   * loaded. If not, the player will be given the option to choose a profile.
    *
    * @returns {Profile} The loaded profile.
    */
   async loadProfile() {
-    const profile = Profile.load(this.runDirectoryPath);
-    if (profile) {
-      return profile;
+    let profile = await Profile.load(this.runDirectoryPath);
+    if (!profile) {
+      profile = await this.chooseProfile();
     }
 
-    return this.chooseProfile();
+    const { towerName } = profile;
+    profile.tower = this.towers.get(towerName);
+    if (!profile.tower) {
+      throw new GameError(
+        `Unable to find tower '${towerName}', make sure it is available.`,
+      );
+    }
+
+    return profile;
   }
 
   /**
@@ -141,7 +149,7 @@ class Game {
       );
     }
 
-    const towerChoices = Tower.getTowers();
+    const towerChoices = Array.from(this.towers.values());
     const tower = await requestChoice('Choose a tower:', towerChoices);
 
     const profileDirectoryPath = path.join(
@@ -224,7 +232,7 @@ class Game {
     this.profile.currentEpicGrades = {};
 
     if (this.practiceLevel) {
-      const hasPracticeLevel = this.tower.hasLevel(this.practiceLevel);
+      const hasPracticeLevel = this.profile.tower.hasLevel(this.practiceLevel);
       if (!hasPracticeLevel) {
         throw new GameError(
           'Unable to practice non-existent level, try another.',
@@ -272,7 +280,7 @@ class Game {
    * @returns {boolean} Whether playing can continue or not (for epic mode),
    */
   async playLevel(levelNumber) {
-    const levelConfig = getLevelConfig(levelNumber, this.tower, this.profile);
+    const levelConfig = getLevelConfig(levelNumber, this.profile);
 
     const level = getLevel(levelConfig);
     printLevel(level);
@@ -309,7 +317,7 @@ class Game {
       return false;
     }
 
-    const hasNextLevel = this.tower.hasLevel(levelNumber + 1);
+    const hasNextLevel = this.profile.tower.hasLevel(levelNumber + 1);
 
     if (hasNextLevel) {
       printSuccessLine('Success! You have found the stairs.');
@@ -345,7 +353,7 @@ class Game {
    * continue on to epic mode.
    */
   async requestNextLevel() {
-    if (this.tower.hasLevel(this.profile.levelNumber + 1)) {
+    if (this.profile.tower.hasLevel(this.profile.levelNumber + 1)) {
       const continueToNextLevel =
         this.assumeYes ||
         (await requestConfirmation(
@@ -388,11 +396,7 @@ class Game {
    * Generates the profile files.
    */
   generateProfileFiles() {
-    const levelConfig = getLevelConfig(
-      this.profile.levelNumber,
-      this.tower,
-      this.profile,
-    );
+    const levelConfig = getLevelConfig(this.profile.levelNumber, this.profile);
     const level = getLevel(levelConfig);
     new ProfileGenerator(this.profile, level).generate();
   }

--- a/packages/warriorjs-cli/src/Game.js
+++ b/packages/warriorjs-cli/src/Game.js
@@ -52,7 +52,7 @@ class Game {
     printLine('Welcome to WarriorJS');
 
     try {
-      this.towers = new Map(loadTowers().map(tower => [tower.name, tower]));
+      this.towers = new Map(loadTowers().map(tower => [tower.id, tower]));
 
       this.profile = await this.loadProfile();
 
@@ -87,11 +87,11 @@ class Game {
       profile = await this.chooseProfile();
     }
 
-    const { towerName } = profile;
-    profile.tower = this.towers.get(towerName);
+    const { towerId } = profile;
+    profile.tower = this.towers.get(towerId);
     if (!profile.tower) {
       throw new GameError(
-        `Unable to find tower '${towerName}', make sure it is available.`,
+        `Unable to find tower '${towerId}', make sure it is available.`,
       );
     }
 
@@ -154,10 +154,10 @@ class Game {
 
     const profileDirectoryPath = path.join(
       this.gameDirectoryPath,
-      `${warriorName}-${tower}`.toLowerCase().replace(/[^a-z0-9]+/g, '-'),
+      `${warriorName}-${tower.id}`.toLowerCase().replace(/[^a-z0-9]+/g, '-'),
     );
 
-    const profile = new Profile(warriorName, tower.name, profileDirectoryPath);
+    const profile = new Profile(warriorName, tower.id, profileDirectoryPath);
 
     if (this.isExistingProfile(profile)) {
       printWarningLine(

--- a/packages/warriorjs-cli/src/Game.test.js
+++ b/packages/warriorjs-cli/src/Game.test.js
@@ -39,13 +39,13 @@ describe('Game', () => {
 
   describe('when loading profile', () => {
     const originalLoad = Profile.load;
-    const profile = { towerName: 'foo' };
-    const tower = { name: 'foo' };
+    const profile = { towerId: 'foo' };
+    const tower = { id: 'foo', name: 'Foo' };
 
     beforeEach(() => {
       Profile.load = jest.fn();
       game.chooseProfile = jest.fn();
-      game.towers = new Map([[tower.name, tower]]);
+      game.towers = new Map([[tower.id, tower]]);
     });
 
     afterEach(() => {
@@ -69,7 +69,7 @@ describe('Game', () => {
     });
 
     test('throws if tower is not available', async () => {
-      profile.towerName = 'bar';
+      profile.towerId = 'bar';
       Profile.load.mockReturnValue(profile);
       await expect(game.loadProfile()).rejects.toThrow(
         new GameError(`Unable to find tower 'bar', make sure it is available.`),

--- a/packages/warriorjs-cli/src/Profile.js
+++ b/packages/warriorjs-cli/src/Profile.js
@@ -35,10 +35,15 @@ class Profile {
     const {
       warriorName,
       towerId,
+      towerName, // TODO: Remove before v1.0.0.
       directoryPath, // TODO: Remove before v1.0.0.
       ...profileData
     } = decodedProfile;
-    const profile = new Profile(warriorName, towerId, profileDirectoryPath);
+    const profile = new Profile(
+      warriorName,
+      towerId || towerName,
+      profileDirectoryPath,
+    );
     return Object.assign(profile, profileData);
   }
 

--- a/packages/warriorjs-cli/src/Profile.js
+++ b/packages/warriorjs-cli/src/Profile.js
@@ -34,11 +34,11 @@ class Profile {
     const decodedProfile = Profile.decode(encodedProfile);
     const {
       warriorName,
-      towerName,
+      towerId,
       directoryPath, // TODO: Remove before v1.0.0.
       ...profileData
     } = decodedProfile;
-    const profile = new Profile(warriorName, towerName, profileDirectoryPath);
+    const profile = new Profile(warriorName, towerId, profileDirectoryPath);
     return Object.assign(profile, profileData);
   }
 
@@ -113,12 +113,12 @@ class Profile {
    * Creates a profile.
    *
    * @param {string} warriorName The name of the warrior.
-   * @param {string} towerName The name of the tower.
+   * @param {string} towerId The identifier of the tower.
    * @param {string} directoryPath The path to the directory of the profile.
    */
-  constructor(warriorName, towerName, directoryPath) {
+  constructor(warriorName, towerId, directoryPath) {
     this.warriorName = warriorName;
-    this.towerName = towerName;
+    this.towerId = towerId;
     this.directoryPath = directoryPath;
     this.levelNumber = 0;
     this.score = 0;
@@ -312,7 +312,7 @@ class Profile {
    * @returns {string} The string representation.
    */
   toString() {
-    let result = `${this.warriorName} - ${this.towerName}`;
+    let result = `${this.warriorName} - ${this.towerId}`;
     if (this.isEpic()) {
       result += ` - first score ${
         this.score

--- a/packages/warriorjs-cli/src/Profile.js
+++ b/packages/warriorjs-cli/src/Profile.js
@@ -9,7 +9,7 @@ const playerCodeFile = 'Player.js';
 const readmeFile = 'README.md';
 
 // Properties ignored when saving the profile.
-const ignoredProperties = ['directoryPath'];
+const ignoredProperties = ['directoryPath', 'tower'];
 
 /** Class representing a profile. */
 class Profile {
@@ -128,6 +128,7 @@ class Profile {
     this.averageGrade = null;
     this.currentEpicScore = 0;
     this.currentEpicGrades = {};
+    this.tower = null;
   }
 
   /**

--- a/packages/warriorjs-cli/src/Profile.test.js
+++ b/packages/warriorjs-cli/src/Profile.test.js
@@ -142,6 +142,10 @@ describe('Profile', () => {
     expect(profile.clue).toBe(false);
   });
 
+  test('has a tower which is null before loading the profile into the game', () => {
+    expect(profile.tower).toBeNull();
+  });
+
   test('makes directory', () => {
     mock({ '/path/to': {} });
     profile.makeProfileDirectory();
@@ -269,7 +273,9 @@ describe('Profile', () => {
     );
   });
 
-  test('encodes with JSON + base64', () => {
+  test('encodes with JSON + base64 ignoring properties', () => {
+    profile.directoryPath = 'ignored';
+    profile.tower = 'ignored';
     expect(profile.encode()).toBe(
       'eyJ3YXJyaW9yTmFtZSI6IkpvZSIsInRvd2VyTmFtZSI6ImJlZ2lubmVyIiwibGV2ZWxOdW1iZXIiOjAsInNjb3JlIjowLCJjbHVlIjpmYWxzZSwiZXBpYyI6ZmFsc2UsImVwaWNTY29yZSI6MCwiYXZlcmFnZUdyYWRlIjpudWxsLCJjdXJyZW50RXBpY1Njb3JlIjowLCJjdXJyZW50RXBpY0dyYWRlcyI6e319',
     );

--- a/packages/warriorjs-cli/src/Profile.test.js
+++ b/packages/warriorjs-cli/src/Profile.test.js
@@ -18,11 +18,11 @@ describe('Profile.load', () => {
   test('instances Profile with contents of profile file', () => {
     Profile.isProfileDirectory = () => true;
     Profile.read = () =>
-      'eyJ3YXJyaW9yTmFtZSI6ICJKb2UiLCAidG93ZXJOYW1lIjogImJlZ2lubmVyIiwgImZvbyI6IDQyfQ==';
+      'eyJ3YXJyaW9yTmFtZSI6ICJKb2UiLCAidG93ZXJJZCI6ICJiZWdpbm5lciIsICJmb28iOiA0Mn0=';
     const profile = Profile.load('/path/to/profile');
     expect(profile).toBeInstanceOf(Profile);
     expect(profile.warriorName).toBe('Joe');
-    expect(profile.towerName).toBe('beginner');
+    expect(profile.towerId).toBe('beginner');
     expect(path.normalize(profile.directoryPath)).toBe(
       path.normalize('/path/to/profile'),
     );
@@ -32,7 +32,7 @@ describe('Profile.load', () => {
   test('updates the path to the directory from where the profile is being loaded', () => {
     Profile.isProfileDirectory = () => true;
     Profile.read = () =>
-      'eyJ3YXJyaW9yTmFtZSI6ICJKb2UiLCAidG93ZXJOYW1lIjogImJlZ2lubmVyIiwgImRpcmVjdG9yeVBhdGgiOiAiL29sZC9wYXRoL3RvL3Byb2ZpbGUifQ==';
+      'eyJ3YXJyaW9yTmFtZSI6ICJKb2UiLCAidG93ZXJJZCI6ICJiZWdpbm5lciJ9';
     const profile = Profile.load('/new/path/to/profile');
     expect(profile.directoryPath).toBe('/new/path/to/profile');
   });
@@ -115,8 +115,8 @@ describe('Profile', () => {
     expect(profile.warriorName).toBe('Joe');
   });
 
-  test('has a tower name', () => {
-    expect(profile.towerName).toBe('beginner');
+  test('has a tower identifier', () => {
+    expect(profile.towerId).toBe('beginner');
   });
 
   test('has a directory path', () => {
@@ -277,7 +277,7 @@ describe('Profile', () => {
     profile.directoryPath = 'ignored';
     profile.tower = 'ignored';
     expect(profile.encode()).toBe(
-      'eyJ3YXJyaW9yTmFtZSI6IkpvZSIsInRvd2VyTmFtZSI6ImJlZ2lubmVyIiwibGV2ZWxOdW1iZXIiOjAsInNjb3JlIjowLCJjbHVlIjpmYWxzZSwiZXBpYyI6ZmFsc2UsImVwaWNTY29yZSI6MCwiYXZlcmFnZUdyYWRlIjpudWxsLCJjdXJyZW50RXBpY1Njb3JlIjowLCJjdXJyZW50RXBpY0dyYWRlcyI6e319',
+      'eyJ3YXJyaW9yTmFtZSI6IkpvZSIsInRvd2VySWQiOiJiZWdpbm5lciIsImxldmVsTnVtYmVyIjowLCJzY29yZSI6MCwiY2x1ZSI6ZmFsc2UsImVwaWMiOmZhbHNlLCJlcGljU2NvcmUiOjAsImF2ZXJhZ2VHcmFkZSI6bnVsbCwiY3VycmVudEVwaWNTY29yZSI6MCwiY3VycmVudEVwaWNHcmFkZXMiOnt9fQ==',
     );
   });
 

--- a/packages/warriorjs-cli/src/Tower.js
+++ b/packages/warriorjs-cli/src/Tower.js
@@ -1,28 +1,4 @@
-import beginner from '@warriorjs/tower-beginner';
-
-const towers = [beginner];
-
 class Tower {
-  /**
-   * Returns the tower with the given name.
-   *
-   * @param {string} towerName The name of the tower.
-   *
-   * @returns {Tower} The tower.
-   */
-  static getTowerByName(towerName) {
-    return Tower.getTowers().find(tower => tower.name === towerName);
-  }
-
-  /**
-   * Returns the available towers.
-   *
-   * @returns {Tower[]} The towers.
-   */
-  static getTowers() {
-    return towers.map(({ name, levels }) => new Tower(name, levels));
-  }
-
   /**
    * Creates a tower.
    *

--- a/packages/warriorjs-cli/src/Tower.js
+++ b/packages/warriorjs-cli/src/Tower.js
@@ -2,10 +2,12 @@ class Tower {
   /**
    * Creates a tower.
    *
+   * @param {string} id The identifier of the tower.
    * @param {string} name The name of the tower.
    * @param {Object[]} levels The levels of the tower.
    */
-  constructor(name, levels) {
+  constructor(id, name, levels) {
+    this.id = id;
     this.name = name;
     this.levels = levels;
   }

--- a/packages/warriorjs-cli/src/Tower.test.js
+++ b/packages/warriorjs-cli/src/Tower.test.js
@@ -1,21 +1,5 @@
 import Tower from './Tower';
 
-describe('Tower.getTowerByName', () => {
-  test('returns tower by name', () => {
-    const originalGetTowers = Tower.getTowers;
-    const tower = new Tower('foo');
-    Tower.getTowers = () => [tower];
-    expect(Tower.getTowerByName('foo')).toBe(tower);
-    Tower.getTowers = originalGetTowers;
-  });
-});
-
-describe('Tower.getTowers', () => {
-  test('returns available towers', () => {
-    expect(Tower.getTowers().map(tower => tower.name)).toEqual(['beginner']);
-  });
-});
-
 describe('Tower', () => {
   let tower;
 

--- a/packages/warriorjs-cli/src/Tower.test.js
+++ b/packages/warriorjs-cli/src/Tower.test.js
@@ -4,7 +4,11 @@ describe('Tower', () => {
   let tower;
 
   beforeEach(() => {
-    tower = new Tower('beginner', ['level1', 'level2']);
+    tower = new Tower('beginner', 'beginner', ['level1', 'level2']);
+  });
+
+  test('has an id', () => {
+    expect(tower.id).toBe('beginner');
   });
 
   test('has a name', () => {

--- a/packages/warriorjs-cli/src/loadTowers.js
+++ b/packages/warriorjs-cli/src/loadTowers.js
@@ -1,0 +1,41 @@
+import path from 'path';
+
+import findUp from 'find-up';
+import globby from 'globby';
+import resolve from 'resolve';
+
+import Tower from './Tower';
+
+const officialTowerPackageJsonPattern = '@warriorjs/tower-*/package.json';
+const communityTowerPackageJsonPattern = 'warriorjs-tower-*/package.json';
+
+/**
+ * Loads the installed towers.
+ *
+ * It searches for official and community towers installed in the nearest
+ * `node_modules` directory that is parent to @warriorjs/cli.
+ *
+ * @returns {Tower[]} The loaded towers.
+ */
+function loadTowers() {
+  const internalTowers = [require('@warriorjs/tower-beginner')]; // eslint-disable-line global-require
+
+  const warriorjsCliDir = findUp.sync('@warriorjs/cli', { cwd: __dirname });
+  const towerSearchDir = findUp.sync('node_modules', { cwd: warriorjsCliDir });
+  const towerPackageJsonPaths = globby.sync(
+    [officialTowerPackageJsonPattern, communityTowerPackageJsonPattern],
+    { cwd: towerSearchDir },
+  );
+  const towerPackageNames = towerPackageJsonPaths.map(path.dirname);
+  const towerRequirePaths = towerPackageNames.map(towerPackageName =>
+    resolve.sync(towerPackageName, { basedir: towerSearchDir }),
+  );
+  const externalTowers = towerRequirePaths.map(
+    towerRequirePath => require(towerRequirePath), // eslint-disable-line global-require, import/no-dynamic-require
+  );
+  return internalTowers
+    .concat(externalTowers)
+    .map(({ name, levels }) => new Tower(name, levels));
+}
+
+export default loadTowers;

--- a/packages/warriorjs-cli/src/loadTowers.test.js
+++ b/packages/warriorjs-cli/src/loadTowers.test.js
@@ -1,0 +1,74 @@
+import mock from 'mock-fs';
+
+import Tower from './Tower';
+import loadTowers from './loadTowers';
+
+jest.mock('@warriorjs/tower-beginner', () => ({
+  name: 'beginner',
+  levels: [],
+}));
+jest.mock('find-up', () => ({
+  sync: () => '/path/to/node_modules',
+}));
+jest.mock('./Tower');
+
+test('loads internal towers', () => {
+  mock({ '/path/to/node_modules/@warriorjs/cli': {} });
+  loadTowers();
+  mock.restore();
+  expect(Tower).toHaveBeenCalledWith('beginner', []);
+});
+
+test('loads official towers', () => {
+  mock({
+    '/path/to/node_modules': {
+      '@warriorjs': {
+        cli: {},
+        'tower-foo': {
+          'package.json': '',
+          'index.js': "module.exports = { name: 'foo', levels: [] }",
+        },
+      },
+    },
+  });
+  loadTowers();
+  mock.restore();
+  expect(Tower).toHaveBeenCalledWith('foo', []);
+});
+
+test('loads community towers', () => {
+  mock({
+    '/path/to/node_modules': {
+      '@warriorjs': {
+        cli: {},
+      },
+      'warriorjs-tower-foo': {
+        'package.json': '',
+        'index.js': "module.exports = { name: 'foo', levels: [] }",
+      },
+    },
+  });
+  loadTowers();
+  mock.restore();
+  expect(Tower).toHaveBeenCalledWith('foo', []);
+});
+
+test("ignores directories that are seemingly towers but don't have a package.json", () => {
+  mock({
+    '/path/to/node_modules': {
+      '@warriorjs': {
+        cli: {},
+        'tower-foo': {
+          'index.js': "module.exports = { name: 'foo', levels: [] }",
+        },
+      },
+      'warriorjs-tower-bar': {
+        'index.js': "module.exports = { name: 'bar', levels: [] }",
+      },
+    },
+  });
+  loadTowers();
+  mock.restore();
+  expect(Tower).not.toHaveBeenCalledWith('foo', []);
+  expect(Tower).not.toHaveBeenCalledWith('bar', []);
+});

--- a/packages/warriorjs-cli/src/loadTowers.test.js
+++ b/packages/warriorjs-cli/src/loadTowers.test.js
@@ -16,7 +16,7 @@ test('loads internal towers', () => {
   mock({ '/path/to/node_modules/@warriorjs/cli': {} });
   loadTowers();
   mock.restore();
-  expect(Tower).toHaveBeenCalledWith('beginner', []);
+  expect(Tower).toHaveBeenCalledWith('beginner', 'beginner', []);
 });
 
 test('loads official towers', () => {
@@ -26,14 +26,14 @@ test('loads official towers', () => {
         cli: {},
         'tower-foo': {
           'package.json': '',
-          'index.js': "module.exports = { name: 'foo', levels: [] }",
+          'index.js': "module.exports = { name: 'Foo', levels: [] }",
         },
       },
     },
   });
   loadTowers();
   mock.restore();
-  expect(Tower).toHaveBeenCalledWith('foo', []);
+  expect(Tower).toHaveBeenCalledWith('foo', 'Foo', []);
 });
 
 test('loads community towers', () => {
@@ -44,13 +44,13 @@ test('loads community towers', () => {
       },
       'warriorjs-tower-foo': {
         'package.json': '',
-        'index.js': "module.exports = { name: 'foo', levels: [] }",
+        'index.js': "module.exports = { name: 'Foo', levels: [] }",
       },
     },
   });
   loadTowers();
   mock.restore();
-  expect(Tower).toHaveBeenCalledWith('foo', []);
+  expect(Tower).toHaveBeenCalledWith('foo', 'Foo', []);
 });
 
 test("ignores directories that are seemingly towers but don't have a package.json", () => {
@@ -59,16 +59,16 @@ test("ignores directories that are seemingly towers but don't have a package.jso
       '@warriorjs': {
         cli: {},
         'tower-foo': {
-          'index.js': "module.exports = { name: 'foo', levels: [] }",
+          'index.js': "module.exports = { name: 'Foo', levels: [] }",
         },
       },
       'warriorjs-tower-bar': {
-        'index.js': "module.exports = { name: 'bar', levels: [] }",
+        'index.js': "module.exports = { name: 'Bar', levels: [] }",
       },
     },
   });
   loadTowers();
   mock.restore();
-  expect(Tower).not.toHaveBeenCalledWith('foo', []);
-  expect(Tower).not.toHaveBeenCalledWith('bar', []);
+  expect(Tower).not.toHaveBeenCalledWith('foo', 'Foo', []);
+  expect(Tower).not.toHaveBeenCalledWith('bar', 'Bar', []);
 });

--- a/packages/warriorjs-cli/src/utils/getLevelConfig.js
+++ b/packages/warriorjs-cli/src/utils/getLevelConfig.js
@@ -6,19 +6,18 @@ import getWarriorAbilities from './getWarriorAbilities';
  * Returns the config for the level with the given number.
  *
  * @param {number} levelNumber The number of the level.
- * @param {Tower} tower The tower.
  * @param {Profile} profile The profile.
  *
  * @returns {Object} The level config.
  */
-function getLevelConfig(levelNumber, tower, profile) {
-  const level = tower.getLevel(levelNumber);
+function getLevelConfig(levelNumber, profile) {
+  const level = profile.tower.getLevel(levelNumber);
   const levels = profile.isEpic()
-    ? tower.levels
-    : tower.levels.slice(0, levelNumber);
+    ? profile.tower.levels
+    : profile.tower.levels.slice(0, levelNumber);
   const abilities = getWarriorAbilities(levels);
   return merge({}, level, {
-    towerName: tower.name,
+    towerName: profile.tower.name,
     number: levelNumber,
     floor: {
       warrior: {

--- a/packages/warriorjs-cli/src/utils/getLevelConfig.test.js
+++ b/packages/warriorjs-cli/src/utils/getLevelConfig.test.js
@@ -3,19 +3,21 @@ import getWarriorAbilities from './getWarriorAbilities';
 
 jest.mock('./getWarriorAbilities');
 
-const tower = {
-  levels: ['level1', 'level2'],
-  getLevel: () => ({ floor: { foo: 42, warrior: { bar: 'baz' } } }),
-};
 const profile = {
+  tower: {
+    name: 'foo',
+    levels: ['level1', 'level2'],
+    getLevel: () => ({ floor: { foo: 42, warrior: { bar: 'baz' } } }),
+  },
   warriorName: 'Joe',
   isEpic: () => false,
 };
 getWarriorAbilities.mockReturnValue('abilities');
 
 test('returns level config', () => {
-  const levelConfig = getLevelConfig(1, tower, profile);
+  const levelConfig = getLevelConfig(1, profile);
   expect(levelConfig).toEqual({
+    towerName: 'foo',
     number: 1,
     floor: {
       foo: 42,
@@ -31,6 +33,6 @@ test('returns level config', () => {
 
 test('gets abilities from all levels if epic', () => {
   profile.isEpic = () => true;
-  getLevelConfig(1, tower, profile);
+  getLevelConfig(1, profile);
   expect(getWarriorAbilities).toHaveBeenCalledWith(['level1', 'level2']);
 });

--- a/packages/warriorjs-cli/src/utils/getTowerId.js
+++ b/packages/warriorjs-cli/src/utils/getTowerId.js
@@ -1,0 +1,12 @@
+const towerIdRegex = /(?:@warriorjs\/|warriorjs-)tower-(.+)/;
+
+/**
+ * Returns the identifier of the tower based on the package name.
+ *
+ * @param {string} towerPackageName The package name of the tower.
+ */
+function getTowerId(towerPackageName) {
+  return towerPackageName.match(towerIdRegex)[1];
+}
+
+export default getTowerId;

--- a/packages/warriorjs-cli/src/utils/getTowerId.test.js
+++ b/packages/warriorjs-cli/src/utils/getTowerId.test.js
@@ -1,0 +1,9 @@
+import getTowerId from './getTowerId';
+
+test('returns the tower id for official towers', () => {
+  expect(getTowerId('@warriorjs/tower-foo')).toBe('foo');
+});
+
+test('returns the tower id for community towers', () => {
+  expect(getTowerId('warriorjs-tower-foo')).toBe('foo');
+});

--- a/packages/warriorjs-tower-beginner/index.js
+++ b/packages/warriorjs-tower-beginner/index.js
@@ -1,13 +1,13 @@
-import { EAST, WEST } from '@warriorjs/geography';
-import {
+const { EAST, WEST } = require('@warriorjs/geography');
+const {
   Archer,
   Captive,
   Sludge,
   ThickSludge,
   Warrior,
   Wizard,
-} from '@warriorjs/units';
-import {
+} = require('@warriorjs/units');
+const {
   attack,
   feel,
   health,
@@ -18,9 +18,9 @@ import {
   think,
   shoot,
   walk,
-} from '@warriorjs/abilities';
+} = require('@warriorjs/abilities');
 
-export default {
+module.exports = {
   name: 'beginner',
   levels: [
     {

--- a/packages/warriorjs-tower-beginner/package.json
+++ b/packages/warriorjs-tower-beginner/package.json
@@ -6,18 +6,12 @@
   "license": "MIT",
   "homepage": "https://warrior.js.org",
   "repository": "https://github.com/olistic/warriorjs/tree/master/packages/warriorjs-tower-beginner",
-  "main": "lib/index.js",
+  "main": "index.js",
   "keywords": [
     "warriorjs-tower"
   ],
-  "files": [
-    "lib"
-  ],
   "publishConfig": {
     "access": "public"
-  },
-  "scripts": {
-    "build": "babel src --out-dir lib"
   },
   "peerDependencies": {
     "@warriorjs/core": "^0.4.0"

--- a/packages/warriorjs-tower-intermediate/index.js
+++ b/packages/warriorjs-tower-intermediate/index.js
@@ -1,6 +1,6 @@
-import { EAST, NORTH, SOUTH, WEST } from '@warriorjs/geography';
-import { Captive, Sludge, ThickSludge, Warrior } from '@warriorjs/units';
-import {
+const { EAST, NORTH, SOUTH, WEST } = require('@warriorjs/geography');
+const { Captive, Sludge, ThickSludge, Warrior } = require('@warriorjs/units');
+const {
   attack,
   bind,
   detonate,
@@ -15,10 +15,10 @@ import {
   rest,
   think,
   walk,
-} from '@warriorjs/abilities';
-import { ticking } from '@warriorjs/effects';
+} = require('@warriorjs/abilities');
+const { ticking } = require('@warriorjs/effects');
 
-export default {
+module.exports = {
   name: 'intermediate',
   levels: [
     {

--- a/packages/warriorjs-tower-intermediate/package.json
+++ b/packages/warriorjs-tower-intermediate/package.json
@@ -6,18 +6,12 @@
   "license": "MIT",
   "homepage": "https://warrior.js.org",
   "repository": "https://github.com/olistic/warriorjs/tree/master/packages/warriorjs-tower-intermediate",
-  "main": "lib/index.js",
+  "main": "index.js",
   "keywords": [
     "warriorjs-tower"
   ],
-  "files": [
-    "lib"
-  ],
   "publishConfig": {
     "access": "public"
-  },
-  "scripts": {
-    "build": "babel src --out-dir lib"
   },
   "peerDependencies": {
     "@warriorjs/core": "^0.4.0"

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -25,6 +25,7 @@
     "socialize": "Socialize",
     "space-api": "Space API",
     "spaces": "Spaces",
+    "towers": "Towers",
     "turn-api": "Turn API",
     "unit-api": "Unit API",
     "units": "Units",

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -1,7 +1,14 @@
 {
   "docs": {
     "Intro": ["overview", "set-up"],
-    "Game": ["object", "gameplay", "perspective", "scoring", "epic-mode"],
+    "Game": [
+      "object",
+      "gameplay",
+      "perspective",
+      "scoring",
+      "epic-mode",
+      "towers"
+    ],
     "Concepts": ["units", "warrior", "abilities", "spaces"],
     "Player API": ["space-api", "unit-api", "turn-api"],
     "Tips & Tricks": ["general-tips", "js-tips", "cli-tips"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -6878,7 +6878,7 @@ resolve@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
-resolve@^1.1.6, resolve@^1.6.0:
+resolve@^1.1.6, resolve@^1.6.0, resolve@^1.7.1:
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.7.1.tgz#aadd656374fd298aee895bc026b8297418677fd3"
   dependencies:


### PR DESCRIPTION
This adds support for community towers, as well as official towers that don't ship with the game. WarriorJS CLI searches for towers (`@warriorjs/tower-*` and `warriorjs-tower-*`) in the nearest parent `node_modules` directory. This should work for both global and local installations of the CLI.

Closes #100 
Fixes #168 