### PR TITLE
Add units array default value

### DIFF
--- a/packages/warriorjs-core/src/loadLevel.js
+++ b/packages/warriorjs-core/src/loadLevel.js
@@ -93,7 +93,7 @@ function loadLevel(
     tip,
     clue,
     timeBonus,
-    floor: { size, stairs, warrior, units },
+    floor: { size, stairs, warrior, units = [] },
   },
   playerCode,
 ) {


### PR DESCRIPTION
This allows to omit the `units` array when defining a level without units.