### PR TITLE
Reduce unit.log() calls

### DIFF
--- a/docs/make/defining-abilities.md
+++ b/docs/make/defining-abilities.md
@@ -46,12 +46,12 @@ function walk(unit) {
     action: true,
     description: 'Move one space in the given direction (forward by default).',
     perform(direction = 'forward') {
-      unit.log(`walks ${direction}`);
       const space = unit.getSpaceAt(direction);
       if (space.isEmpty()) {
         unit.move(direction);
+        unit.log(`walks ${direction}`);
       } else {
-        unit.log(`bumps into ${space}`);
+        unit.log(`walks ${direction} and bumps into ${space}`);
       }
     },
   };

--- a/docs/make/refactoring.md
+++ b/docs/make/refactoring.md
@@ -55,12 +55,12 @@ function walk(unit) {
     action: true,
     description: 'Move one space in the given direction (forward by default).',
     perform(direction = 'forward') {
-      unit.log(`walks ${direction}`);
       const space = unit.getSpaceAt(direction);
       if (space.isEmpty()) {
         unit.move(direction);
+        unit.log(`walks ${direction}`);
       } else {
-        unit.log(`bumps into ${space}`);
+        unit.log(`walks ${direction} and bumps into ${space}`);
       }
     },
   };
@@ -344,12 +344,12 @@ function walk(unit) {
     action: true,
     description: 'Move one space in the given direction (forward by default).',
     perform(direction = FORWARD) {
-      unit.log(`walks ${direction}`);
       const space = unit.getSpaceAt(direction);
       if (space.isEmpty()) {
         unit.move(direction);
+        unit.log(`walks ${direction}`);
       } else {
-        unit.log(`bumps into ${space}`);
+        unit.log(`walks ${direction} and bumps into ${space}`);
       }
     },
   };

--- a/packages/warriorjs-abilities/src/pivot.js
+++ b/packages/warriorjs-abilities/src/pivot.js
@@ -7,8 +7,8 @@ function pivot() {
     action: true,
     description: `Rotate in the given direction (${defaultDirection} by default).`,
     perform(direction = defaultDirection) {
-      unit.log(`pivots ${direction}`);
       unit.rotate(direction);
+      unit.log(`pivots ${direction}`);
     },
   });
 }

--- a/packages/warriorjs-abilities/src/walk.js
+++ b/packages/warriorjs-abilities/src/walk.js
@@ -7,12 +7,12 @@ function walk() {
     action: true,
     description: `Move one space in the given direction (${defaultDirection} by default).`,
     perform(direction = defaultDirection) {
-      unit.log(`walks ${direction}`);
       const space = unit.getSpaceAt(direction);
       if (space.isEmpty()) {
         unit.move(direction);
+        unit.log(`walks ${direction}`);
       } else {
-        unit.log(`bumps into ${space}`);
+        unit.log(`walks ${direction} and bumps into ${space}`);
       }
     },
   });

--- a/packages/warriorjs-abilities/src/walk.test.js
+++ b/packages/warriorjs-abilities/src/walk.test.js
@@ -43,8 +43,9 @@ describe('walk', () => {
         toString: () => 'space',
       });
       walk.perform();
-      expect(unit.log).toHaveBeenCalledWith(`walks ${FORWARD}`);
-      expect(unit.log).toHaveBeenLastCalledWith('bumps into space');
+      expect(unit.log).toHaveBeenCalledWith(
+        `walks ${FORWARD} and bumps into space`,
+      );
       expect(unit.move).not.toHaveBeenCalled();
     });
 

--- a/packages/warriorjs-core/src/Unit.js
+++ b/packages/warriorjs-core/src/Unit.js
@@ -108,7 +108,6 @@ class Unit {
         ? this.maxHealth - this.health
         : amount;
     this.health += revisedAmount;
-
     this.log(`receives ${amount} health, up to ${this.health} health`);
   }
 
@@ -124,12 +123,11 @@ class Unit {
 
     const revisedAmount = this.health - amount < 0 ? this.health : amount;
     this.health -= revisedAmount;
-
     this.log(`takes ${amount} damage, ${this.health} health power left`);
 
     if (this.health === 0) {
-      this.log('dies');
       this.vanish();
+      this.log('dies');
     }
   }
 
@@ -167,11 +165,12 @@ class Unit {
    * @param {Unit} receiver The unit to release.
    */
   release(receiver) {
-    receiver.unbind();
     if (!receiver.as(this).isEnemy()) {
-      receiver.vanish();
       this.earnPoints(receiver.reward);
+      receiver.vanish();
     }
+
+    receiver.unbind();
   }
 
   /**
@@ -347,7 +346,6 @@ class Unit {
    */
   move(direction, forward = 1, right = 0) {
     this.position.move(direction, [forward, right]);
-    this.log();
   }
 
   /**
@@ -357,7 +355,6 @@ class Unit {
    */
   rotate(direction) {
     this.position.rotate(direction);
-    this.log();
   }
 
   /**
@@ -365,7 +362,6 @@ class Unit {
    */
   vanish() {
     this.position = null;
-    this.log();
   }
 
   /**

--- a/packages/warriorjs-core/src/Unit.js
+++ b/packages/warriorjs-core/src/Unit.js
@@ -166,11 +166,13 @@ class Unit {
    */
   release(receiver) {
     if (!receiver.as(this).isEnemy()) {
-      this.earnPoints(receiver.reward);
       receiver.vanish();
     }
 
     receiver.unbind();
+    if (!receiver.isAlive()) {
+      this.earnPoints(receiver.reward);
+    }
   }
 
   /**

--- a/packages/warriorjs-core/src/Unit.test.js
+++ b/packages/warriorjs-core/src/Unit.test.js
@@ -474,11 +474,6 @@ describe('Unit', () => {
       unit.move(LEFT);
       expect(unit.position.move).toHaveBeenCalledWith(LEFT, [1, 0]);
     });
-
-    test('murmurs something', () => {
-      unit.move(FORWARD);
-      expect(unit.log).toHaveBeenCalled();
-    });
   });
 
   describe('when rotating', () => {
@@ -490,11 +485,6 @@ describe('Unit', () => {
       unit.rotate(RIGHT);
       expect(unit.position.rotate).toHaveBeenCalledWith(RIGHT);
     });
-
-    test('murmurs something', () => {
-      unit.rotate(BACKWARD);
-      expect(unit.log).toHaveBeenCalled();
-    });
   });
 
   describe('when vanishing', () => {
@@ -502,11 +492,6 @@ describe('Unit', () => {
       expect(unit.position).not.toBeNull();
       unit.vanish();
       expect(unit.position).toBeNull();
-    });
-
-    test('murmurs something', () => {
-      unit.vanish();
-      expect(unit.log).toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
No longer make `unit.log()` calls without message. We used to do that in order to log changes in the unit's position.