### PR TITLE
Optimize level and events

### DIFF
--- a/packages/warriorjs-cli/src/ui/getUnitStyle.js
+++ b/packages/warriorjs-cli/src/ui/getUnitStyle.js
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 
-const warriorStyle = chalk.cyan;
 const unitStyles = [
+  chalk.cyan,
   chalk.magenta,
   chalk.red,
   chalk.yellow,
@@ -12,18 +12,12 @@ const unitStyles = [
 /**
  * Returns the style for the given unit.
  *
- * @param {Object} unit The unit to get the style for.
- * @param {string} unit.character The character that represents the unit.
- * @param {boolean} unit.warrior Whether the unit is the warrior or not.
+ * @param {string} unitName The name of the unit to get the style for.
  *
  * @returns {Function} The style function.
  */
-function getUnitStyle({ character, warrior }) {
-  if (warrior) {
-    return warriorStyle;
-  }
-
-  return unitStyles[character.charCodeAt(0) % unitStyles.length];
+function getUnitStyle(unitName) {
+  return unitStyles[unitName.charCodeAt(0) % unitStyles.length];
 }
 
 export default getUnitStyle;

--- a/packages/warriorjs-cli/src/ui/getUnitStyle.test.js
+++ b/packages/warriorjs-cli/src/ui/getUnitStyle.test.js
@@ -2,14 +2,7 @@ import style from 'ansi-styles';
 
 import getUnitStyle from './getUnitStyle';
 
-test('returns cyan style function for warrior', () => {
-  const warriorStyle = getUnitStyle({ warrior: true });
-  expect(warriorStyle('@')).toEqual(`${style.cyan.open}@${style.cyan.close}`);
-});
-
-test('returns calculated style function for other units', () => {
-  const unitStyle = getUnitStyle({ character: 's' });
-  expect(unitStyle('s')).toEqual(
-    `${style.magenta.open}s${style.magenta.close}`,
-  );
+test("returns calculated style function based on unit's name", () => {
+  const unitStyle = getUnitStyle('foo');
+  expect(unitStyle('f')).toEqual(`${style.cyan.open}f${style.cyan.close}`);
 });

--- a/packages/warriorjs-cli/src/ui/printBoard.js
+++ b/packages/warriorjs-cli/src/ui/printBoard.js
@@ -9,17 +9,18 @@ const warriorStatusRows = 2;
 /**
  * Prints the game board after moving the cursor up a given number of rows.
  *
- * @param {Object} floor The level floor.
+ * @param {Object[][]} floorMap The map of the floor.
+ * @param {Object} warriorStatus The status of the warrior.
  * @param {number} offset The number of rows.
  */
-function printBoard(floor, offset) {
+function printBoard(floorMap, warriorStatus, offset) {
   if (offset > 0) {
-    const floorMapRows = floor.map.length;
+    const floorMapRows = floorMap.length;
     print(ansiEscapes.cursorUp(offset + floorMapRows + warriorStatusRows));
   }
 
-  printWarriorStatus(floor.warrior);
-  printFloorMap(floor.map);
+  printWarriorStatus(warriorStatus);
+  printFloorMap(floorMap);
 
   if (offset > 0) {
     print(ansiEscapes.cursorDown(offset));

--- a/packages/warriorjs-cli/src/ui/printBoard.test.js
+++ b/packages/warriorjs-cli/src/ui/printBoard.test.js
@@ -10,24 +10,20 @@ jest.mock('./printFloorMap');
 jest.mock('./printWarriorStatus');
 
 test('prints warrior status and floor map', () => {
-  const floor = {
-    map: {},
-    warrior: {},
-  };
-  printBoard(floor);
+  const floorMap = ['row1', 'row2'];
+  const warriorStatus = 'status';
+  printBoard(floorMap, warriorStatus);
   expect(print).not.toHaveBeenCalled();
-  expect(printWarriorStatus).toHaveBeenCalledWith(floor.warrior);
-  expect(printFloorMap).toHaveBeenCalledWith(floor.map);
+  expect(printWarriorStatus).toHaveBeenCalledWith(warriorStatus);
+  expect(printFloorMap).toHaveBeenCalledWith(floorMap);
 });
 
 test('moves cursor up and down with offset', () => {
-  const floor = {
-    map: { length: 1 },
-    warrior: {},
-  };
-  printBoard(floor, 1);
-  expect(print).toHaveBeenCalledWith(ansiEscapes.cursorUp(4));
-  expect(printWarriorStatus).toHaveBeenCalledWith(floor.warrior);
-  expect(printFloorMap).toHaveBeenCalledWith(floor.map);
+  const floorMap = ['row1', 'row2'];
+  const warriorStatus = 'status';
+  printBoard(floorMap, warriorStatus, 1);
+  expect(print).toHaveBeenCalledWith(ansiEscapes.cursorUp(5));
+  expect(printWarriorStatus).toHaveBeenCalledWith(warriorStatus);
+  expect(printFloorMap).toHaveBeenCalledWith(floorMap);
   expect(print).toHaveBeenCalledWith(ansiEscapes.cursorDown(1));
 });

--- a/packages/warriorjs-cli/src/ui/printFloorMap.js
+++ b/packages/warriorjs-cli/src/ui/printFloorMap.js
@@ -4,24 +4,25 @@ import printLine from './printLine';
 /**
  * Prints the floor map.
  *
- * @param {Object} map The map of the floor.
+ * @param {Object[][]} floorMap The map of the floor.
  */
-function printFloorMap(map) {
-  const floorMap = map
-    .map(row =>
-      row
-        .map(({ character, unit }) => {
-          if (unit) {
-            const style = getUnitStyle(unit);
-            return style(character);
-          }
+function printFloorMap(floorMap) {
+  printLine(
+    floorMap
+      .map(row =>
+        row
+          .map(({ character, unit }) => {
+            if (unit) {
+              const style = getUnitStyle(unit.name);
+              return style(character);
+            }
 
-          return character;
-        })
-        .join(''),
-    )
-    .join('\n');
-  printLine(floorMap);
+            return character;
+          })
+          .join(''),
+      )
+      .join('\n'),
+  );
 }
 
 export default printFloorMap;

--- a/packages/warriorjs-cli/src/ui/printFloorMap.test.js
+++ b/packages/warriorjs-cli/src/ui/printFloorMap.test.js
@@ -9,11 +9,11 @@ test('prints floor map', () => {
   const style = jest.fn(unit => unit);
   getUnitStyle.mockImplementation(() => style);
   const map = [
-    [{ character: 'a' }, { character: 'b', unit: 'unit' }],
-    [{ character: 'c' }, { character: 'd' }],
+    [{ character: 'a' }, { character: 'f', unit: { name: 'foo' } }],
+    [{ character: 'b' }, { character: 'c' }],
   ];
   printFloorMap(map);
-  expect(getUnitStyle).toHaveBeenCalledWith('unit');
-  expect(style).toHaveBeenCalledWith('b');
-  expect(printLine).toHaveBeenCalledWith('ab\ncd');
+  expect(getUnitStyle).toHaveBeenCalledWith('foo');
+  expect(style).toHaveBeenCalledWith('f');
+  expect(printLine).toHaveBeenCalledWith('af\nbc');
 });

--- a/packages/warriorjs-cli/src/ui/printLevel.js
+++ b/packages/warriorjs-cli/src/ui/printLevel.js
@@ -6,11 +6,11 @@ import printLevelHeader from './printLevelHeader';
  *
  * @param {Object} level The level to print.
  * @param {number} level.number The number of the level.
- * @param {Object} level.floor.map The map of the floor.
+ * @param {Object[][]} level.floorMap The map of the floor.
  */
-function printLevel({ number, floor: { map } }) {
+function printLevel({ number, floorMap }) {
   printLevelHeader(number);
-  printFloorMap(map);
+  printFloorMap(floorMap);
 }
 
 export default printLevel;

--- a/packages/warriorjs-cli/src/ui/printLevel.test.js
+++ b/packages/warriorjs-cli/src/ui/printLevel.test.js
@@ -9,7 +9,7 @@ test('prints level header, description, and floor map', () => {
   const level = {
     number: 1,
     description: 'foo',
-    floor: { map: 'map' },
+    floorMap: 'map',
   };
   printLevel(level);
   expect(printLevelHeader).toHaveBeenCalledWith(1);

--- a/packages/warriorjs-cli/src/ui/printLogMessage.js
+++ b/packages/warriorjs-cli/src/ui/printLogMessage.js
@@ -7,12 +7,13 @@ import printLine from './printLine';
  * Prints a message to the log.
  *
  * @param {Object} unit The unit the message belongs to.
+ * @param {string} unit.name The name of the unit.
  * @param {string} message The message to print.
  */
-function printLogMessage(unit, message) {
+function printLogMessage({ name }, message) {
   const prompt = chalk.gray.dim('>');
-  const style = getUnitStyle(unit);
-  const logMessage = style(`${unit.name} ${message}`);
+  const style = getUnitStyle(name);
+  const logMessage = style(`${name} ${message}`);
   printLine(`${prompt} ${logMessage}`);
 }
 

--- a/packages/warriorjs-cli/src/ui/printPlay.js
+++ b/packages/warriorjs-cli/src/ui/printPlay.js
@@ -24,7 +24,7 @@ async function printPlay(events, delay) {
 
     // eslint-disable-next-line no-restricted-syntax
     for (const event of turnEvents) {
-      printBoard(event.floor, boardOffset);
+      printBoard(event.floorMap, event.warriorStatus, boardOffset);
       printLogMessage(event.unit, event.message);
       boardOffset += 1;
 

--- a/packages/warriorjs-cli/src/ui/printPlay.test.js
+++ b/packages/warriorjs-cli/src/ui/printPlay.test.js
@@ -18,10 +18,13 @@ test('prints turn header on each new turn', async () => {
 });
 
 test('prints board on each event', async () => {
-  const events = [[{ floor: 'floor1' }], [{ floor: 'floor2' }]];
+  const events = [
+    [{ floorMap: 'floor1', warriorStatus: 'status1' }],
+    [{ floorMap: 'floor2', warriorStatus: 'status2' }],
+  ];
   await printPlay(events);
-  expect(printBoard).toHaveBeenCalledWith('floor1', 0);
-  expect(printBoard).toHaveBeenCalledWith('floor2', 0);
+  expect(printBoard).toHaveBeenCalledWith('floor1', 'status1', 0);
+  expect(printBoard).toHaveBeenCalledWith('floor2', 'status2', 0);
 });
 
 test('prints log message on each event', async () => {
@@ -44,10 +47,10 @@ test('starts counting board offset from zero, increments on each event and reset
     [{ unit: 'foo', message: 'bar' }],
   ];
   await printPlay(events);
-  expect(printBoard.mock.calls[0][1]).toBe(0);
-  expect(printBoard.mock.calls[1][1]).toBe(1);
-  expect(printBoard.mock.calls[2][1]).toBe(0);
-  expect(printBoard.mock.calls[3][1]).toBe(0);
+  expect(printBoard.mock.calls[0][2]).toBe(0);
+  expect(printBoard.mock.calls[1][2]).toBe(1);
+  expect(printBoard.mock.calls[2][2]).toBe(0);
+  expect(printBoard.mock.calls[3][2]).toBe(0);
 });
 
 test('sleeps the specified time at the beginning and after each event', async () => {

--- a/packages/warriorjs-cli/src/ui/printWarriorStatus.js
+++ b/packages/warriorjs-cli/src/ui/printWarriorStatus.js
@@ -5,13 +5,13 @@ import printRow from './printRow';
 /**
  * Prints the warrior status line.
  *
- * @param {Object} warrior The warrior.
+ * @param {Object} warriorStatus The status of the warrior.
+ * @param {number} warriorStatus.health The health of the warrior.
+ * @param {number} warriorStatus.score The score of the warrior.
  */
-function printWarriorStatus(warrior) {
-  const warriorHealth = chalk.redBright(`♥ ${warrior.health}`);
-  printRow(warriorHealth);
-  const warriorScore = chalk.yellowBright(`♦ ${warrior.score}`);
-  printRow(warriorScore);
+function printWarriorStatus({ health, score }) {
+  printRow(chalk.redBright(`♥ ${health}`));
+  printRow(chalk.yellowBright(`♦ ${score}`));
 }
 
 export default printWarriorStatus;

--- a/packages/warriorjs-cli/src/ui/printWarriorStatus.test.js
+++ b/packages/warriorjs-cli/src/ui/printWarriorStatus.test.js
@@ -6,20 +6,20 @@ import printWarriorStatus from './printWarriorStatus';
 jest.mock('./printRow');
 
 test('prints warrior health in bright red', () => {
-  const warrior = {
+  const warriorStatus = {
     health: 20,
   };
-  printWarriorStatus(warrior);
+  printWarriorStatus(warriorStatus);
   expect(printRow).toHaveBeenCalledWith(
     `${style.redBright.open}♥ 20${style.redBright.close}`,
   );
 });
 
 test('prints warrior score in bright yellow', () => {
-  const warrior = {
+  const warriorStatus = {
     score: 10,
   };
-  printWarriorStatus(warrior);
+  printWarriorStatus(warriorStatus);
   expect(printRow).toHaveBeenCalledWith(
     `${style.yellowBright.open}♦ 10${style.yellowBright.close}`,
   );

--- a/packages/warriorjs-cli/src/utils/getFloorMapKey.js
+++ b/packages/warriorjs-cli/src/utils/getFloorMapKey.js
@@ -1,21 +1,18 @@
 function getFloorMapKey(map) {
   return map
     .reduce((acc, row) => acc.concat(row), [])
-    .filter(space => space.stairs || space.unit)
+    .filter(space => space.unit)
     .filter(
       (space, index, arr) =>
         arr.findIndex(
           anotherSpace => anotherSpace.character === space.character,
         ) === index,
     )
-    .map(({ character, stairs, unit }) => {
-      if (stairs) {
-        return `${character} = stairs`;
-      }
-
+    .map(({ character, unit }) => {
       const { name, maxHealth } = unit;
       return `${character} = ${name} (${maxHealth} HP)`;
     })
+    .concat(['> = stairs'])
     .join('\n');
 }
 

--- a/packages/warriorjs-cli/src/utils/getFloorMapKey.test.js
+++ b/packages/warriorjs-cli/src/utils/getFloorMapKey.test.js
@@ -6,7 +6,7 @@ test('returns the floor map key', () => {
       { character: '@', unit: { name: 'Joe', maxHealth: 20 } },
       { character: 'b' },
     ],
-    [{ character: 'c' }, { character: '>', stairs: true }],
+    [{ character: 'c' }],
   ];
   expect(getFloorMapKey(map)).toBe('@ = Joe (20 HP)\n> = stairs');
 });

--- a/packages/warriorjs-cli/src/utils/getLevelConfig.js
+++ b/packages/warriorjs-cli/src/utils/getLevelConfig.js
@@ -17,7 +17,6 @@ function getLevelConfig(levelNumber, profile) {
     : profile.tower.levels.slice(0, levelNumber);
   const abilities = getWarriorAbilities(levels);
   return merge({}, level, {
-    towerId: profile.tower.id,
     number: levelNumber,
     floor: {
       warrior: {

--- a/packages/warriorjs-cli/src/utils/getLevelConfig.test.js
+++ b/packages/warriorjs-cli/src/utils/getLevelConfig.test.js
@@ -5,7 +5,6 @@ jest.mock('./getWarriorAbilities');
 
 const profile = {
   tower: {
-    id: 'foo',
     name: 'Foo',
     levels: ['level1', 'level2'],
     getLevel: () => ({ floor: { foo: 42, warrior: { bar: 'baz' } } }),
@@ -18,7 +17,6 @@ getWarriorAbilities.mockReturnValue('abilities');
 test('returns level config', () => {
   const levelConfig = getLevelConfig(1, profile);
   expect(levelConfig).toEqual({
-    towerId: 'foo',
     number: 1,
     floor: {
       foo: 42,

--- a/packages/warriorjs-cli/templates/README.md.ejs
+++ b/packages/warriorjs-cli/templates/README.md.ejs
@@ -12,7 +12,7 @@
 
 <%-
   include('readme/abilities', {
-    abilities: level.floor.warrior.abilities,
+    abilities: level.warriorAbilities,
   });
 -%>
 

--- a/packages/warriorjs-cli/templates/readme/abilities.ejs
+++ b/packages/warriorjs-cli/templates/readme/abilities.ejs
@@ -1,18 +1,13 @@
-<%_
-  const sortedAbilities = abilities.sort((a, b) => a.name > b.name);
-  const actions = sortedAbilities.filter(ability => ability.action);
-  const senses = sortedAbilities.filter(ability => !ability.action);
-_%>
 ### Actions (only one per turn)
 
-<% actions.forEach(ability => { -%>
+<% abilities.actions.forEach(ability => { -%>
 <%- include('ability', { ability }); %>
 <% }); -%>
-<% if (senses.length) { -%>
+<% if (abilities.senses.length) { -%>
 
 ### Senses
 
-<% senses.forEach(ability => { -%>
+<% abilities.senses.forEach(ability => { -%>
 <%- include('ability', { ability }); %>
 <% }); -%>
 <% } -%>

--- a/packages/warriorjs-cli/templates/readme/level.ejs
+++ b/packages/warriorjs-cli/templates/readme/level.ejs
@@ -9,7 +9,7 @@ _<%- level.description %>_
 ### Floor Map
 
 ```
-<%- getFloorMap(level.floor.map) %>
+<%- getFloorMap(level.floorMap) %>
 
-<%- getFloorMapKey(level.floor.map) %>
+<%- getFloorMapKey(level.floorMap) %>
 ```

--- a/packages/warriorjs-core/src/Floor.js
+++ b/packages/warriorjs-core/src/Floor.js
@@ -124,18 +124,6 @@ class Floor {
   getUnits() {
     return this.units.filter(unit => unit.isAlive());
   }
-
-  /**
-   * Customizes the JSON stringification behavior of the floor.
-   *
-   * @returns {Object} The value to be serialized.
-   */
-  toJSON() {
-    return {
-      map: this.getMap(),
-      warrior: this.warrior,
-    };
-  }
 }
 
 export default Floor;

--- a/packages/warriorjs-core/src/Level.js
+++ b/packages/warriorjs-core/src/Level.js
@@ -104,6 +104,22 @@ class Level {
       warriorScore,
     };
   }
+
+  /**
+   * Customizes the JSON stringification behavior of the level.
+   *
+   * @returns {Object} The value to be serialized.
+   */
+  toJSON() {
+    return {
+      number: this.number,
+      description: this.description,
+      tip: this.tip,
+      clue: this.clue,
+      floorMap: this.floor.getMap(),
+      warriorAbilities: this.floor.warrior.getAbilities(),
+    };
+  }
 }
 
 export default Level;

--- a/packages/warriorjs-core/src/Level.js
+++ b/packages/warriorjs-core/src/Level.js
@@ -7,7 +7,6 @@ class Level {
   /**
    * Creates a level.
    *
-   * @param {string} towerId The identifier of the tower.
    * @param {number} number The number of the level.
    * @param {string} description The description of the level.
    * @param {string} tip A tip for the level.
@@ -15,8 +14,7 @@ class Level {
    * @param {number} timeBonus The bonus for completing the level fast.
    * @param {Floor} floor The floor of the level.
    */
-  constructor(towerId, number, description, tip, clue, timeBonus, floor) {
-    this.towerId = towerId;
+  constructor(number, description, tip, clue, timeBonus, floor) {
     this.number = number;
     this.description = description;
     this.tip = tip;

--- a/packages/warriorjs-core/src/Level.test.js
+++ b/packages/warriorjs-core/src/Level.test.js
@@ -16,9 +16,7 @@ describe('Level', () => {
     floor = new Floor(2, 1, [1, 0]);
     floor.addUnit(warrior, { x: 0, y: 0, facing: EAST });
     floor.warrior = warrior;
-    level = new Level();
-    level.timeBonus = 10;
-    level.floor = floor;
+    level = new Level(1, 'a description', 'a tip', 'a clue', 10, floor);
   });
 
   describe('playing', () => {
@@ -91,6 +89,17 @@ describe('Level', () => {
     test("doesn't have clear bonus when not clearing the level", () => {
       warrior.getOtherUnits = () => [new Unit()];
       expect(level.getScore().clearBonus).toBe(0);
+    });
+  });
+
+  test('has a minimal JSON representation', () => {
+    expect(level.toJSON()).toEqual({
+      number: 1,
+      description: 'a description',
+      tip: 'a tip',
+      clue: 'a clue',
+      floorMap: level.floor.getMap(),
+      warriorAbilities: level.floor.warrior.getAbilities(),
     });
   });
 });

--- a/packages/warriorjs-core/src/Logger.js
+++ b/packages/warriorjs-core/src/Logger.js
@@ -26,7 +26,8 @@ const Logger = {
     Logger.lastTurn.push({
       message,
       unit: JSON.parse(JSON.stringify(unit)),
-      floor: JSON.parse(JSON.stringify(Logger.floor)),
+      floorMap: JSON.parse(JSON.stringify(Logger.floor.getMap())),
+      warriorStatus: Logger.floor.warrior.getStatus(),
     });
   },
 };

--- a/packages/warriorjs-core/src/Space.js
+++ b/packages/warriorjs-core/src/Space.js
@@ -183,7 +183,6 @@ class Space {
   toJSON() {
     return {
       character: this.getCharacter(),
-      stairs: this.isStairs(),
       unit: this.getUnit(),
     };
   }

--- a/packages/warriorjs-core/src/Space.test.js
+++ b/packages/warriorjs-core/src/Space.test.js
@@ -287,4 +287,11 @@ describe('Space', () => {
       expect(fullSpace.location).toEqual(space.location);
     });
   });
+
+  test('has a minimal JSON representation', () => {
+    expect(space.toJSON()).toEqual({
+      character: space.getCharacter(),
+      unit: space.getUnit(),
+    });
+  });
 });

--- a/packages/warriorjs-core/src/Unit.js
+++ b/packages/warriorjs-core/src/Unit.js
@@ -407,9 +407,7 @@ class Unit {
   toJSON() {
     return {
       name: this.name,
-      character: this.character,
       maxHealth: this.maxHealth,
-      health: this.health,
     };
   }
 }

--- a/packages/warriorjs-core/src/Unit.test.js
+++ b/packages/warriorjs-core/src/Unit.test.js
@@ -554,4 +554,11 @@ describe('Unit', () => {
   test('has a nice string representation', () => {
     expect(unit.toString()).toBe(unit.name);
   });
+
+  test('has a minimal JSON representation', () => {
+    expect(unit.toJSON()).toEqual({
+      name: 'Joe',
+      maxHealth: 20,
+    });
+  });
 });

--- a/packages/warriorjs-core/src/Warrior.js
+++ b/packages/warriorjs-core/src/Warrior.js
@@ -30,6 +30,32 @@ class Warrior extends Unit {
     this.log(`loses ${points} points`);
   }
 
+  /**
+   * Returns a grouped collection of abilities.
+   *
+   * @returns {Object} The collection of abilities.
+   */
+  getAbilities() {
+    const abilities = [...this.abilities].map(
+      ([name, { action, description }]) => ({
+        name,
+        action,
+        description,
+      }),
+    );
+    const sortedAbilities = abilities.sort((a, b) => a.name > b.name);
+    const actions = sortedAbilities
+      .filter(ability => ability.action)
+      .map(({ action, ...rest }) => rest);
+    const senses = sortedAbilities
+      .filter(ability => !ability.action)
+      .map(({ action, ...rest }) => rest);
+    return {
+      actions,
+      senses,
+    };
+  }
+
   toJSON() {
     return {
       ...super.toJSON(),

--- a/packages/warriorjs-core/src/Warrior.js
+++ b/packages/warriorjs-core/src/Warrior.js
@@ -69,19 +69,6 @@ class Warrior extends Unit {
       score: this.score,
     };
   }
-
-  toJSON() {
-    return {
-      ...super.toJSON(),
-      warrior: true,
-      score: this.score,
-      abilities: [...this.abilities].map(([name, { action, description }]) => ({
-        name,
-        action,
-        description,
-      })),
-    };
-  }
 }
 
 export default Warrior;

--- a/packages/warriorjs-core/src/Warrior.js
+++ b/packages/warriorjs-core/src/Warrior.js
@@ -56,6 +56,20 @@ class Warrior extends Unit {
     };
   }
 
+  /**
+   * Returns the status of the warrior.
+   *
+   * The status includes the current health and score values.
+   *
+   * @returns {Object} The status of the warrior.
+   */
+  getStatus() {
+    return {
+      health: this.health,
+      score: this.score,
+    };
+  }
+
   toJSON() {
     return {
       ...super.toJSON(),

--- a/packages/warriorjs-core/src/Warrior.test.js
+++ b/packages/warriorjs-core/src/Warrior.test.js
@@ -39,4 +39,11 @@ describe('Warrior', () => {
       senses: [{ name: 'feel', description: 'a description' }],
     });
   });
+
+  test('has a status', () => {
+    expect(warrior.getStatus()).toEqual({
+      health: 20,
+      score: 0,
+    });
+  });
 });

--- a/packages/warriorjs-core/src/Warrior.test.js
+++ b/packages/warriorjs-core/src/Warrior.test.js
@@ -5,6 +5,8 @@ describe('Warrior', () => {
 
   beforeEach(() => {
     warrior = new Warrior('Joe', '@', 20);
+    warrior.addAbility('feel', { description: 'a description' });
+    warrior.addAbility('walk', { action: true, description: 'a description' });
     warrior.log = jest.fn();
   });
 
@@ -29,5 +31,12 @@ describe('Warrior', () => {
   test('is upset for losing points', () => {
     warrior.losePoints(5);
     expect(warrior.log).toHaveBeenCalledWith('loses 5 points');
+  });
+
+  test('has a grouped collection of abilities', () => {
+    expect(warrior.getAbilities()).toEqual({
+      actions: [{ name: 'walk', description: 'a description' }],
+      senses: [{ name: 'feel', description: 'a description' }],
+    });
   });
 });

--- a/packages/warriorjs-core/src/getLevel.test.js
+++ b/packages/warriorjs-core/src/getLevel.test.js
@@ -104,27 +104,6 @@ test('returns level', () => {
           unit: {
             name: 'Joe',
             maxHealth: 20,
-            warrior: true,
-            score: 0,
-            abilities: [
-              {
-                name: 'walk',
-                action: true,
-                description:
-                  'Move one space in the given direction (forward by default).',
-              },
-              {
-                name: 'attack',
-                action: true,
-                description:
-                  'Attack a unit in the given direction (forward by default) dealing 5 HP of damage.',
-              },
-              {
-                name: 'feel',
-                description:
-                  'Return the adjacent space in the given direction (forward by default).',
-              },
-            ],
           },
         },
         { character: ' ' },

--- a/packages/warriorjs-core/src/getLevel.test.js
+++ b/packages/warriorjs-core/src/getLevel.test.js
@@ -3,7 +3,6 @@ import { EAST, FORWARD, RELATIVE_DIRECTIONS, WEST } from '@warriorjs/geography';
 import getLevel from './getLevel';
 
 const levelConfig = {
-  towerId: 'beginner',
   number: 2,
   description: "It's too dark to see anything, but you smell sludge nearby.",
   tip:
@@ -79,7 +78,6 @@ const levelConfig = {
 
 test('returns level', () => {
   expect(getLevel(levelConfig)).toEqual({
-    towerId: 'beginner',
     number: 2,
     description: "It's too dark to see anything, but you smell sludge nearby.",
     tip:

--- a/packages/warriorjs-core/src/getLevel.test.js
+++ b/packages/warriorjs-core/src/getLevel.test.js
@@ -137,10 +137,8 @@ test('returns level', () => {
           stairs: false,
           unit: {
             name: 'Joe',
-            character: '@',
             maxHealth: 20,
             warrior: true,
-            health: 20,
             score: 0,
             abilities: [
               {
@@ -180,9 +178,7 @@ test('returns level', () => {
           stairs: false,
           unit: {
             name: 'Sludge',
-            character: 's',
             maxHealth: 12,
-            health: 12,
           },
         },
         {

--- a/packages/warriorjs-core/src/getLevel.test.js
+++ b/packages/warriorjs-core/src/getLevel.test.js
@@ -84,196 +84,187 @@ test('returns level', () => {
       "Use `warrior.feel().isEmpty()` to see if there's anything in front of you, and `warrior.attack()` to fight it. Remember, you can only do one action per turn.",
     clue:
       'Add an if/else condition using `warrior.feel().isEmpty()` to decide whether to attack or walk.',
-    timeBonus: 20,
-    floor: {
-      map: [
-        [
-          {
-            character: '╔',
-            stairs: false,
-          },
-          {
-            character: '═',
-            stairs: false,
-          },
-          {
-            character: '═',
-            stairs: false,
-          },
-          {
-            character: '═',
-            stairs: false,
-          },
-          {
-            character: '═',
-            stairs: false,
-          },
-          {
-            character: '═',
-            stairs: false,
-          },
-          {
-            character: '═',
-            stairs: false,
-          },
-          {
-            character: '═',
-            stairs: false,
-          },
-          {
-            character: '═',
-            stairs: false,
-          },
-          {
-            character: '╗',
-            stairs: false,
-          },
-        ],
-        [
-          {
-            character: '║',
-            stairs: false,
-          },
-          {
-            character: '@',
-            stairs: false,
-            unit: {
-              name: 'Joe',
-              character: '@',
-              maxHealth: 20,
-              warrior: true,
-              health: 20,
-              score: 0,
-              abilities: [
-                {
-                  name: 'walk',
-                  action: true,
-                  description:
-                    'Move one space in the given direction (forward by default).',
-                },
-                {
-                  name: 'attack',
-                  action: true,
-                  description:
-                    'Attack a unit in the given direction (forward by default) dealing 5 HP of damage.',
-                },
-                {
-                  name: 'feel',
-                  description:
-                    'Return the adjacent space in the given direction (forward by default).',
-                },
-              ],
-            },
-          },
-          {
-            character: ' ',
-            stairs: false,
-          },
-          {
-            character: ' ',
-            stairs: false,
-          },
-          {
-            character: ' ',
-            stairs: false,
-          },
-          {
-            character: 's',
-            stairs: false,
-            unit: {
-              name: 'Sludge',
-              character: 's',
-              maxHealth: 12,
-              health: 12,
-            },
-          },
-          {
-            character: ' ',
-            stairs: false,
-          },
-          {
-            character: ' ',
-            stairs: false,
-          },
-          {
-            character: '>',
-            stairs: true,
-          },
-          {
-            character: '║',
-            stairs: false,
-          },
-        ],
-        [
-          {
-            character: '╚',
-            stairs: false,
-          },
-          {
-            character: '═',
-            stairs: false,
-          },
-          {
-            character: '═',
-            stairs: false,
-          },
-          {
-            character: '═',
-            stairs: false,
-          },
-          {
-            character: '═',
-            stairs: false,
-          },
-          {
-            character: '═',
-            stairs: false,
-          },
-          {
-            character: '═',
-            stairs: false,
-          },
-          {
-            character: '═',
-            stairs: false,
-          },
-          {
-            character: '═',
-            stairs: false,
-          },
-          {
-            character: '╝',
-            stairs: false,
-          },
-        ],
+    floorMap: [
+      [
+        {
+          character: '╔',
+          stairs: false,
+        },
+        {
+          character: '═',
+          stairs: false,
+        },
+        {
+          character: '═',
+          stairs: false,
+        },
+        {
+          character: '═',
+          stairs: false,
+        },
+        {
+          character: '═',
+          stairs: false,
+        },
+        {
+          character: '═',
+          stairs: false,
+        },
+        {
+          character: '═',
+          stairs: false,
+        },
+        {
+          character: '═',
+          stairs: false,
+        },
+        {
+          character: '═',
+          stairs: false,
+        },
+        {
+          character: '╗',
+          stairs: false,
+        },
       ],
-      warrior: {
-        name: 'Joe',
-        character: '@',
-        maxHealth: 20,
-        warrior: true,
-        abilities: [
-          {
-            name: 'walk',
-            action: true,
-            description:
-              'Move one space in the given direction (forward by default).',
+      [
+        {
+          character: '║',
+          stairs: false,
+        },
+        {
+          character: '@',
+          stairs: false,
+          unit: {
+            name: 'Joe',
+            character: '@',
+            maxHealth: 20,
+            warrior: true,
+            health: 20,
+            score: 0,
+            abilities: [
+              {
+                name: 'walk',
+                action: true,
+                description:
+                  'Move one space in the given direction (forward by default).',
+              },
+              {
+                name: 'attack',
+                action: true,
+                description:
+                  'Attack a unit in the given direction (forward by default) dealing 5 HP of damage.',
+              },
+              {
+                name: 'feel',
+                description:
+                  'Return the adjacent space in the given direction (forward by default).',
+              },
+            ],
           },
-          {
-            name: 'attack',
-            action: true,
-            description:
-              'Attack a unit in the given direction (forward by default) dealing 5 HP of damage.',
+        },
+        {
+          character: ' ',
+          stairs: false,
+        },
+        {
+          character: ' ',
+          stairs: false,
+        },
+        {
+          character: ' ',
+          stairs: false,
+        },
+        {
+          character: 's',
+          stairs: false,
+          unit: {
+            name: 'Sludge',
+            character: 's',
+            maxHealth: 12,
+            health: 12,
           },
-          {
-            name: 'feel',
-            description:
-              'Return the adjacent space in the given direction (forward by default).',
-          },
-        ],
-        health: 20,
-        score: 0,
-      },
+        },
+        {
+          character: ' ',
+          stairs: false,
+        },
+        {
+          character: ' ',
+          stairs: false,
+        },
+        {
+          character: '>',
+          stairs: true,
+        },
+        {
+          character: '║',
+          stairs: false,
+        },
+      ],
+      [
+        {
+          character: '╚',
+          stairs: false,
+        },
+        {
+          character: '═',
+          stairs: false,
+        },
+        {
+          character: '═',
+          stairs: false,
+        },
+        {
+          character: '═',
+          stairs: false,
+        },
+        {
+          character: '═',
+          stairs: false,
+        },
+        {
+          character: '═',
+          stairs: false,
+        },
+        {
+          character: '═',
+          stairs: false,
+        },
+        {
+          character: '═',
+          stairs: false,
+        },
+        {
+          character: '═',
+          stairs: false,
+        },
+        {
+          character: '╝',
+          stairs: false,
+        },
+      ],
+    ],
+    warriorAbilities: {
+      actions: [
+        {
+          name: 'attack',
+          description:
+            'Attack a unit in the given direction (forward by default) dealing 5 HP of damage.',
+        },
+        {
+          name: 'walk',
+          description:
+            'Move one space in the given direction (forward by default).',
+        },
+      ],
+      senses: [
+        {
+          name: 'feel',
+          description:
+            'Return the adjacent space in the given direction (forward by default).',
+        },
+      ],
     },
   });
 });

--- a/packages/warriorjs-core/src/getLevel.test.js
+++ b/packages/warriorjs-core/src/getLevel.test.js
@@ -86,55 +86,21 @@ test('returns level', () => {
       'Add an if/else condition using `warrior.feel().isEmpty()` to decide whether to attack or walk.',
     floorMap: [
       [
-        {
-          character: '╔',
-          stairs: false,
-        },
-        {
-          character: '═',
-          stairs: false,
-        },
-        {
-          character: '═',
-          stairs: false,
-        },
-        {
-          character: '═',
-          stairs: false,
-        },
-        {
-          character: '═',
-          stairs: false,
-        },
-        {
-          character: '═',
-          stairs: false,
-        },
-        {
-          character: '═',
-          stairs: false,
-        },
-        {
-          character: '═',
-          stairs: false,
-        },
-        {
-          character: '═',
-          stairs: false,
-        },
-        {
-          character: '╗',
-          stairs: false,
-        },
+        { character: '╔' },
+        { character: '═' },
+        { character: '═' },
+        { character: '═' },
+        { character: '═' },
+        { character: '═' },
+        { character: '═' },
+        { character: '═' },
+        { character: '═' },
+        { character: '╗' },
       ],
       [
-        {
-          character: '║',
-          stairs: false,
-        },
+        { character: '║' },
         {
           character: '@',
-          stairs: false,
           unit: {
             name: 'Joe',
             maxHealth: 20,
@@ -161,84 +127,32 @@ test('returns level', () => {
             ],
           },
         },
-        {
-          character: ' ',
-          stairs: false,
-        },
-        {
-          character: ' ',
-          stairs: false,
-        },
-        {
-          character: ' ',
-          stairs: false,
-        },
+        { character: ' ' },
+        { character: ' ' },
+        { character: ' ' },
         {
           character: 's',
-          stairs: false,
           unit: {
             name: 'Sludge',
             maxHealth: 12,
           },
         },
-        {
-          character: ' ',
-          stairs: false,
-        },
-        {
-          character: ' ',
-          stairs: false,
-        },
-        {
-          character: '>',
-          stairs: true,
-        },
-        {
-          character: '║',
-          stairs: false,
-        },
+        { character: ' ' },
+        { character: ' ' },
+        { character: '>' },
+        { character: '║' },
       ],
       [
-        {
-          character: '╚',
-          stairs: false,
-        },
-        {
-          character: '═',
-          stairs: false,
-        },
-        {
-          character: '═',
-          stairs: false,
-        },
-        {
-          character: '═',
-          stairs: false,
-        },
-        {
-          character: '═',
-          stairs: false,
-        },
-        {
-          character: '═',
-          stairs: false,
-        },
-        {
-          character: '═',
-          stairs: false,
-        },
-        {
-          character: '═',
-          stairs: false,
-        },
-        {
-          character: '═',
-          stairs: false,
-        },
-        {
-          character: '╝',
-          stairs: false,
-        },
+        { character: '╚' },
+        { character: '═' },
+        { character: '═' },
+        { character: '═' },
+        { character: '═' },
+        { character: '═' },
+        { character: '═' },
+        { character: '═' },
+        { character: '═' },
+        { character: '╝' },
       ],
     ],
     warriorAbilities: {

--- a/packages/warriorjs-core/src/loadLevel.js
+++ b/packages/warriorjs-core/src/loadLevel.js
@@ -87,7 +87,6 @@ function loadUnit(
  */
 function loadLevel(
   {
-    towerId,
     number,
     description,
     tip,
@@ -104,7 +103,7 @@ function loadLevel(
   loadWarrior(warrior, floor, playerCode);
   units.forEach(unit => loadUnit(unit, floor));
 
-  return new Level(towerId, number, description, tip, clue, timeBonus, floor);
+  return new Level(number, description, tip, clue, timeBonus, floor);
 }
 
 export default loadLevel;

--- a/packages/warriorjs-core/src/runLevel.js
+++ b/packages/warriorjs-core/src/runLevel.js
@@ -6,7 +6,7 @@ import loadLevel from './loadLevel';
  * @param {Object} levelConfig The config of the level.
  * @param {string} playerCode The code of the player.
  *
- * @returns {Object} The outcome of the play.
+ * @returns {Object} The result of the play.
  */
 function runLevel(levelConfig, playerCode) {
   const level = loadLevel(levelConfig, playerCode);


### PR DESCRIPTION
Optimize shapes of level and play events, reducing the size of the payloads.

Version | Level payload size | Events payload size
--------|-------------------|--------------------
`v0.6.0` | 2K | 41K
`v0.7.0` | 2K | 15K
This PR | 1.1K | 5K

_Tests performed by JSON-stringifying the payloads when playing level 1 of beginner's tower._

**This signifies a ~45% and ~88% reduction on the level payload size and the events payload size, respectively, based on version `v0.6.0`.**