### PR TITLE
Fix think ability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Think ability with complex thoughts
+
 ## [0.11.3] - 2018-07-24
 
 ### Added

--- a/packages/warriorjs-abilities/src/think.js
+++ b/packages/warriorjs-abilities/src/think.js
@@ -1,9 +1,11 @@
+import util from 'util';
+
 function think() {
   return unit => ({
-    description:
-      'Think about your options before choosing an action (`console.log` replacement).',
-    perform(thought) {
-      unit.log(`thinks ${thought || 'nothing'}`);
+    description: 'Think out loud (`console.log` replacement).',
+    perform(...args) {
+      const thought = args.length > 0 ? util.format(...args) : 'nothing';
+      unit.log(`thinks ${thought}`);
     },
   });
 }

--- a/packages/warriorjs-abilities/src/think.test.js
+++ b/packages/warriorjs-abilities/src/think.test.js
@@ -15,7 +15,7 @@ describe('think', () => {
 
   test('has a description', () => {
     expect(think.description).toBe(
-      'Think about your options before choosing an action (`console.log` replacement).',
+      'Think out loud (`console.log` replacement).',
     );
   });
 
@@ -28,6 +28,11 @@ describe('think', () => {
     test('allows to specify thought', () => {
       think.perform('he should be brave');
       expect(unit.log).toHaveBeenCalledWith('thinks he should be brave');
+    });
+
+    test('allows complex thoughts', () => {
+      think.perform('that %o', { brave: true });
+      expect(unit.log).toHaveBeenCalledWith('thinks that { brave: true }');
     });
   });
 });


### PR DESCRIPTION
Previously, `warrior.think({ foo: 'bar' })` printed `Spartacus thinks [object Object]`. This PR fixes that, plus makes the behavior of `warrior.think()` almost the same as `console.log()`.