### PR TITLE
Add pivot ability to Tick Tick Boom tower

### DIFF
--- a/packages/warriorjs-tower-tick-tick-boom/src/index.js
+++ b/packages/warriorjs-tower-tick-tick-boom/src/index.js
@@ -12,6 +12,7 @@ import {
   listen,
   look,
   maxHealth,
+  pivot,
   rescue,
   rest,
   think,
@@ -141,6 +142,7 @@ export default {
           },
           abilities: {
             bind: bind(),
+            pivot: pivot(),
             rescue: rescue(),
           },
         },

--- a/packages/warriorjs-tower-tick-tick-boom/src/index.js
+++ b/packages/warriorjs-tower-tick-tick-boom/src/index.js
@@ -81,6 +81,7 @@ export default {
             feel: feel(),
             health: health(),
             maxHealth: maxHealth(),
+            pivot: pivot(),
             rest: rest({ healthGain: 0.1 }),
           },
           position: {
@@ -142,7 +143,6 @@ export default {
           },
           abilities: {
             bind: bind(),
-            pivot: pivot(),
             rescue: rescue(),
           },
         },


### PR DESCRIPTION
By issue #242 @warriorjs/tower-tick-tick-boom warrior haven't got the "pivot" ability and bashing 'backward' forcedly
https://github.com/olistic/warriorjs/issues/242