### PR TITLE
Check after each effect if the unit is still alive before performing actions

### DIFF
--- a/packages/warriorjs-core/src/Unit.js
+++ b/packages/warriorjs-core/src/Unit.js
@@ -92,8 +92,13 @@ class Unit {
    */
   performTurn() {
     if (this.isAlive()) {
-      this.effects.forEach(effect => effect.passTurn());
-      if (this.turn.action && !this.isBound()) {
+      const diedAfterEffects = Array.from(this.effects.values()).some(
+        effect => {
+          effect.passTurn();
+          return !this.isAlive();
+        },
+      );
+      if (!diedAfterEffects && this.turn.action && !this.isBound()) {
         const [name, args] = this.turn.action;
         this.abilities.get(name).perform(...args);
       }

--- a/packages/warriorjs-core/src/Unit.test.js
+++ b/packages/warriorjs-core/src/Unit.test.js
@@ -172,6 +172,17 @@ describe('Unit', () => {
     expect(walk.perform).toHaveBeenCalledWith('backward');
   });
 
+  test("doesn't perform action if the unit died after effects", () => {
+    const poison = { passTurn: () => unit.takeDamage(2) };
+    const walk = { perform: jest.fn() };
+    unit.health = 1;
+    unit.addEffect('poison', poison);
+    unit.addAbility('walk', walk);
+    unit.turn = { action: ['walk', []] };
+    unit.performTurn();
+    expect(walk.perform).toHaveBeenCalledTimes(0);
+  });
+
   test("doesn't throw when calling performTurn when there is no action", () => {
     unit.turn = { action: null };
     unit.performTurn();


### PR DESCRIPTION
I used `some` to check if after any effect the unit.isAlive() would return false.
In case the unit is not alive after any effect, it will skip the next iterations and return true to `diedAfterEffects`.

Then, I added another check (`!diedAfterEffects`) before starting to perform the unit actions.

Let me know if you think this can be improved in any way.