### PR TITLE
feat: Insert a level 3 to Baby Steps tower and shift subsequent levels

### DIFF
--- a/packages/warriorjs-tower-baby-steps/README.md
+++ b/packages/warriorjs-tower-baby-steps/README.md
@@ -19,3 +19,35 @@ warriorjs
 ```
 
 For more in depth documentation see: https://warrior.js.org/docs/player/towers.
+
+## Levels
+
+### Level 3: Healing Intro
+
+_You sense a larger sludge ahead, but you feel a bit weaker than usual._
+
+> **TIP:** You must heal between battles! Use `warrior.health()` to check your
+> health and `warrior.rest()` to regain health before fighting the second
+> sludge.
+
+#### Floor Map
+
+```
+╔══════╗
+║@ s s>║
+╚══════╝
+
+@ = Warrior (10 HP)
+s = Sludge (12 HP)
+> = stairs
+```
+
+#### Abilities
+
+- `warrior.health()`: Returns your current health.
+- `warrior.rest()`: Regain 10% of max health (2 HP per rest).
+- `warrior.walk()`: Move forward.
+- `warrior.attack()`: Attack a unit in front.
+
+_All subsequent levels are shifted up by one (old Level 3 → 4, etc.) to maintain
+progression._

--- a/packages/warriorjs-tower-baby-steps/src/index.js
+++ b/packages/warriorjs-tower-baby-steps/src/index.js
@@ -98,6 +98,50 @@ export default {
         ],
       },
     },
+    // Healing Intro Level (new Level 3)
+    {
+      description:
+        'You sense a larger sludge ahead, but you feel a bit weaker than usual.',
+      tip:
+        'You must heal between battles! Use `warrior.health()` to check your health and `warrior.rest()` to regain health before fighting the second sludge.',
+      clue:
+        "When there's no enemy ahead of you, call `warrior.rest()` until your health is full before walking forward.",
+      timeBonus: 30,
+      aceScore: 40,
+      floor: {
+        size: {
+          width: 6,
+          height: 1,
+        },
+        stairs: {
+          x: 5,
+          y: 0,
+        },
+        warrior: {
+          ...Warrior,
+          abilities: {
+            health: health(),
+            rest: rest({ healthGain: 0.1 }),
+          },
+          position: {
+            x: 0,
+            y: 0,
+            facing: EAST,
+          },
+          health: 10, // low health to require healing
+        },
+        units: [
+          {
+            ...Sludge,
+            position: { x: 2, y: 0, facing: WEST },
+          },
+          {
+            ...Sludge,
+            position: { x: 4, y: 0, facing: WEST },
+          },
+        ],
+      },
+    },
     {
       description:
         'The air feels thicker than before. There must be a horde of sludge.',


### PR DESCRIPTION
# Insert a level 3 to Baby Steps tower and shift subsequent levels WarriorJS

## Description

This PR introduces a new Level 3 ("Healing Intro") to the Baby Steps tower in WarriorJS.  
The level is designed to gently teach players how to manage health using `warrior.rest()`, without overwhelming them.

## Motivation
The goal is to gradually introduce the healing mechanic so new players aren’t immediately confronted with multiple enemies or high-damage encounters.  
By starting with low health and only two sludges, players are encouraged to use `warrior.rest()` and develop a survival strategy.

## Key Changes

- **New Level 3: Healing Intro**
  - Warrior starts with low health (10 HP) in a 6×1 hallway.
  - Two sludges positioned along the path.
  - Players must use `warrior.rest()` strategically to survive both encounters.
  - Level description and tip emphasize health management and healing.

- **Level Renumbering**
  - All subsequent levels are shifted up by one index (old Level 3 → Level 4, etc.) to maintain sequential progression.

- **Updated Package README**
  - Added a "Levels" section documenting the new Level 3.
  - Includes description, tip, floor map, and warrior abilities.
  - Noted that all subsequent levels are renumbered.

## Testing

- Verified locally that the new level appears and works as intended in both the CLI and the generated profile README.
- Confirmed that only the intended files were updated—no unrelated changes included.

## Impact

This addition ensures a smoother learning curve and prevents overwhelming new players, while introducing the important healing mechanic at the right time.

---

